### PR TITLE
Add RTX A6000 48GB community A/B numbers (Q8_K_XL, 256K context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Ran the A/B on your card? Open a PR and add a row.
 |---|---|---|---|---|---|
 | RTX 3090 24GB | 31.0 | 41.3 | 2 | 0.78 | [@sudoingX](https://x.com/sudoingX) |
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
-| RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | n/a | [@lingster](https://github.com/lingster) |
+| RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ Ran the A/B on your card? Open a PR and add a row.
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 
+### A6000 48GB: n-max sweep
+
+Same A6000, same config as the row above, `--spec-draft-n-max` swept 2-6. Overall and per-prompt probe medians (tok/s), draft acceptance from the server log:
+
+| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|
+| 2 | 52.5 | 57.0 | 43.1 | 52.5 | 0.54-0.98 |
+| 3 | 60.7 | 67.6 | 44.1 | 60.7 | 0.42-0.91 |
+| **4** | **64.1** | 77.1 | 41.6 | 64.1 | 0.32-0.93 |
+| 5 | 62.8 | 80.5 | 40.8 | 62.8 | 0.29-0.84 |
+| 6 | 58.6 | 84.3 | 37.4 | 58.6 | 0.23-0.84 |
+
+The overall peak is n-max 4 here, not 2 — the card has enough headroom to absorb the cost of deeper verification before the acceptance decay eats the win. Same shape as the 5090 sweep: the code prompts keep rising all the way up (84.3 at n-max 6), the prose prompt falls from the start (43.1 -> 37.4), and acceptance decays monotonically. Daily mixed use: 4, pure code sessions: 5-6, prose-heavy: 2.
+
 ## License
 
 Apache-2.0. The numbers and verdicts are real, the conclusions are mine.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Ran the A/B on your card? Open a PR and add a row.
 |---|---|---|---|---|---|
 | RTX 3090 24GB | 31.0 | 41.3 | 2 | 0.78 | [@sudoingX](https://x.com/sudoingX) |
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
+| RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | n/a | [@lingster](https://github.com/lingster) |
+
+\* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 
 ## License
 


### PR DESCRIPTION
Community A/B run on an RTX A6000 48GB (Ada).

- Baseline (no spec): 26.7 tok/s median, 40.0 GB VRAM
- With `--spec-type draft-mtp --spec-draft-n-max 2 --parallel 1`: 52.5 tok/s median, 41.4 GB VRAM (+97%)

Method: same paired A/B as the README — live llama-server, probe.py streaming client, thinking off, warmup discarded, medians of 3 runs x 3 prompts.

Deviations from the standard setup (noted in the README footnote below the table): unsloth Q8_K_XL, `-c 256142`, q8_0 KV cache. Acceptance was not logged during these runs, so the table row carries `n/a`.