### PR TITLE
Add RX 7900 XTX 24GB community A/B numbers (Q4_K_M, 131K context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 3090 24GB | 31.0 | 41.3 | 2 | 0.78 | [@sudoingX](https://x.com/sudoingX) |
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
+| RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
+\* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
 
 ### A6000 48GB: n-max sweep
 


### PR DESCRIPTION
Community A/B run on an RX 7900 XTX 24GB.

- Baseline (no spec): 30.7 tok/s median, 18.9 GB VRAM
- With `--spec-type draft-mtp --spec-draft-n-max 2 --parallel 1`: 43.9 tok/s median, 19.7 GB VRAM (+43%)

### n-max sweep 2-6

| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
|---|---|---|---|---|---|
| **2** | **43.9** | 47.7 | 34.3 | 43.9 | 0.60-0.95 |
| 3 | 42.0 | 50.2 | 35.1 | 42.0 | 0.42-0.90 |
| 4 | 43.7 | 50.4 | 28.1 | 43.7 | 0.33-0.86 |
| 5 | 39.7 | 54.4 | 27.9 | 39.7 | 0.32-0.91 |
| 6 | 33.5 | 51.3 | 23.1 | 33.5 | 0.25-0.80 |

PowerColor RX 7900 XTX: 272W cap, 2371 MHz core / 1249 MHz mem, -50 mV undervolt.

Done by [@Jqianggu](https://x.com/Jqianggu).