### PR TITLE
Add 3× RTX 3090-class 24GB TP3 community A/B (UD-Q6_K_XL, n-max 2–6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
+| 2× RTX 3090 + 3090 Ti 24GB (TP) | 49.1 | 81.1 | 2 | 0.52-0.96 | [@guilhermedemelocabral](https://github.com/guilhermedemelocabral) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
+\* 3×24GB TP row: two RTX 3090 + one 3090 Ti, Unsloth UD-Q6_K_XL, tensor-parallel `--split-mode tensor`, `--parallel 4`, 500K unified KV pool, q8_0 KV, f16 draft KV, mmproj Q8, temp 1.0. VRAM ~16.6 GB/GPU baseline, ~18.7 GB/GPU with spec (tightest card). Method: stock `probe.py`. `--parallel 1` was not required on this host.
 
 ### A6000 48GB: n-max sweep
 
@@ -93,6 +95,20 @@ Same A6000, same config as the row above, `--spec-draft-n-max` swept 2-6. Overal
 | 6 | 58.6 | 84.3 | 37.4 | 58.6 | 0.23-0.84 |
 
 The overall peak is n-max 4 here, not 2 — the card has enough headroom to absorb the cost of deeper verification before the acceptance decay eats the win. Same shape as the 5090 sweep: the code prompts keep rising all the way up (84.3 at n-max 6), the prose prompt falls from the start (43.1 -> 37.4), and acceptance decays monotonically. Daily mixed use: 4, pure code sessions: 5-6, prose-heavy: 2.
+
+### 3× RTX 3090 / 3090 Ti 24GB (TP): n-max sweep
+
+Same 3×24GB host, same config as the row above, `--spec-draft-n-max` swept 2-6. Overall and per-prompt probe medians (tok/s), draft acceptance from the server log:
+
+| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|
+| 2 | 81.1 | 96.2 | 68.8 | 81.1 | 0.52-0.96 |
+| **3** | **95.6** | 108.1 | 71.1 | 95.6 | 0.38-0.92 |
+| 4 | 94.9 | 114.7 | 67.2 | 94.9 | 0.37-0.92 |
+| 5 | 93.3 | 115.9 | 55.7 | 93.3 | 0.29-0.84 |
+| 6 | 88.7 | 112.9 | 54.1 | 88.7 | 0.25-0.80 |
+
+Overall peaks at n-max 3. Code keeps climbing through n-max 5 (115.9); prose falls after n-max 3 (71.1 → 54.1). Same shape as the 5090 and A6000 sweeps. Daily mixed use: 2–3; pure code: 4–5; prose-heavy: 2. A separate greedy code-completion hash gate (not `probe.py`) matched n-max 2 and diverged at n-max 1/3/4; chaining `ngram-mod` made n-max 2 unstable on that gate, so this host still ships n-max 2 without ngram.
 
 ## License
 


### PR DESCRIPTION
Community A/B on 3× 24GB (2× RTX 3090 + RTX 3090 Ti), tensor-parallel.

- Baseline (no spec): 49.1 tok/s median
- `--spec-type draft-mtp --spec-draft-n-max 2 --parallel 4`: 81.1 tok/s median (+65%)
- Acceptance n=2: 0.52–0.96 (server log, warmup excluded)

Method: same paired A/B as the README — live llama-server, probe.py streaming client, thinking off, warmup discarded, medians of 3 runs × 3 prompts.

Deviations from the 24GB Q4 recipe (footnoted): Unsloth UD-Q6_K_XL, tensor split, `--parallel 4`, 500K unified KV pool, q8_0 KV / f16 draft KV, mmproj Q8, temp 1.0. `--parallel 1` is not required on this host.

n-max sweep 2–6 completed on this pool. Overall peak is n-max 3 (95.6); code prompts keep rising through n-max 5; prose falls after 3.

Correctness (greedy hash gate, not probe.py): n-max 2 matched a deterministic Python completion 3/3. n-max 1/3/4 changed the generated code. ngram-mod made n=2 unstable on that gate. We keep n-max 2 without ngram.