### PR TITLE
Add RTX 4090 UD-Q4_K_XL 160K community numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
+| RTX 4090 24GB (UD-Q4_K_XL) | 36.1 | 74.8 | 2 | 0.56-0.94 | [@rkvhtd](https://github.com/rkvhtd) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
+\* RTX 4090 row: unsloth UD-Q4_K_XL, 160K context, q4_0 KV cache, llama.cpp b10360, Windows/CUDA, 275W power limit — 20.6 GB VRAM baseline, 21.9 GB with spec.
 
 ### A6000 48GB: n-max sweep
 


### PR DESCRIPTION
Community A/B run on an RTX 4090 24GB using the repository's unchanged `probe.py`.

- Baseline (no spec): 36.1 tok/s median, 20.6 GB VRAM
- MTP2: 74.8 tok/s median, 21.9 GB VRAM (+107%)
- Acceptance: 0.56-0.94

Method: same paired A/B as the README, live llama-server, thinking off, warmup discarded, medians of 3 runs x 3 prompts.

Config: Unsloth UD-Q4_K_XL, 160K context, q4_0 KV cache, llama.cpp b10360, Windows/CUDA, 275W power limit, no mmproj.

This is a different quant and serving configuration from #5.
