### PR TITLE
Add 2x RX 9070 16GB (Vulkan) community A/B numbers, plus a --spec-draft-p-min sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
+| 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
+\* RX 9070 row: two 16GB cards on one 31.84 GiB pool, Vulkan build b10426, unsloth UD-Q4_K_XL, **262K context**, q8_0 KV cache — 28.0 GiB across the pool with spec. Method differs from the rows above and is spelled out under the sweep below.
 
 ### A6000 48GB: n-max sweep
 
@@ -93,6 +95,28 @@ Same A6000, same config as the row above, `--spec-draft-n-max` swept 2-6. Overal
 | 6 | 58.6 | 84.3 | 37.4 | 58.6 | 0.23-0.84 |
 
 The overall peak is n-max 4 here, not 2 — the card has enough headroom to absorb the cost of deeper verification before the acceptance decay eats the win. Same shape as the 5090 sweep: the code prompts keep rising all the way up (84.3 at n-max 6), the prose prompt falls from the start (43.1 -> 37.4), and acceptance decays monotonically. Daily mixed use: 4, pure code sessions: 5-6, prose-heavy: 2.
+
+### 2x RX 9070 16GB: n-max sweep, and the second knob nobody is turning
+
+Same pair of cards, same config as the RX 9070 row above, at the full 262K window. Decode medians (tok/s) at three prompt depths, draft acceptance from the server log:
+
+| config | ~0 ctx | 16K | 65K | Acceptance |
+|---|---|---|---|---|
+| spec off | 22.1 | 21.0 | — | — |
+| n-max 2, no gating | 41.6 | 37.2 | 28.0 | 0.73 |
+| **n-max 4, `--spec-draft-p-min 0.60`** | **42.9** | **38.5** | 27.4 | 0.86 |
+| n-max 4, `--spec-draft-p-min 0.75` | 38.3 | 36.6 | **28.9** | 0.91 |
+| n-max 4, `--spec-draft-p-min 0.80` | 40.7 | 35.5 | — | 0.90 |
+| n-max 8, any p-min | 30.0-36.7 | 31.8-33.9 | — | 0.74-0.84 |
+
+**`--spec-draft-n-max` alone is only half the tuning.** `--spec-draft-p-min` is a confidence gate: the head stops drafting once its own probability falls below the threshold, so a deeper n-max costs nothing on the rounds where the draft was going to be rejected anyway. That is what makes n-max 4 usable here — ungated n-max 4 was worse than n-max 2, and gated at 0.60 it drafts ~3.3 tokens per round at 0.86 acceptance instead of exactly 2.0 at 0.73. On a copy-heavy prompt (rename-and-echo over a 4K-token file) the gated arm is **+21%** over the deployed n-max 2, well above the +3% it shows on mixed work. n-max 8 loses at every gate value.
+
+Two things this rig says that the NVIDIA rows do not:
+
+- **The delta is much larger and the ceiling is the same.** +88% at n-max 2, +94% at the tuned setting, against +33-39% on the 24GB NVIDIA cards — because the *baseline* is unusually bad here, not because the flag is better. Vulkan on RDNA4 at batch-1 decodes across two cards serially, so 22.1 tok/s unassisted; with the head engaged it lands at 41.6-42.9, the same absolute band as everyone else. If your card is bandwidth-poor at batch 1, this flag is worth more to you than to a 3090 owner.
+- **N=1 crowned the wrong arm.** A single-run screen put p-min 0.75 on top; medians of 3 flipped the winner to 0.60. The noise band here is around +/-2 tok/s, which is wide enough to invert a ranking. Do reps before you deploy a config.
+
+Method note, since it is not the repo's: numbers come from a local greedy streaming harness (max 1200 tokens) rather than `probe.py`, all in one session against one server instance with only the spec flags varying. The n-max 2 and p-min 0.60 arms are medians of 3; the spec-off, p-min 0.75/0.80 and n-max 8 arms are single screening runs. Treat the sweep as a shape, and the two headline arms as measurements.
 
 ## License
 


### PR DESCRIPTION
Ran the A/B on a pair of RX 9070 16GB cards (single 31.84 GiB pool, Vulkan `b10426`, unsloth UD-Q4_K_XL, 262K context, q8_0 KV, `--parallel 1`). Adds one table row and a sweep section.

**Row:** 22.1 → 41.6 tok/s at n-max 2, acceptance 0.73. That is **+88%**, well outside the +33-39% band on the NVIDIA rows — but the reason is the baseline, not the flag. Vulkan on RDNA4 decodes serially across the two cards at batch 1, so unassisted decode is only 22.1; with the head engaged it lands at 41.6-42.9, the same absolute band as the 24GB rows. Worth having in the table precisely because it shows the flag pays *most* on the cards that need it most.

**Sweep section** covers something no row here uses yet: `--spec-draft-p-min`. Gating the draft on the head's own confidence is what makes a deeper n-max usable — ungated n-max 4 was worse than n-max 2 on this rig, and gated at 0.60 it drafts ~3.3 tokens/round at 0.86 acceptance instead of exactly 2.0 at 0.73, for 42.9 tok/s and +21% on copy-heavy work. n-max 8 loses at every gate value. If it is useful to the A6000 and 5090 sweeps, `--spec-draft-p-min 0.60` is one flag away.

Also included, since it cost me a wrong deployment: a single-run screen crowned p-min 0.75, and medians of 3 flipped the winner to 0.60. The noise band is about ±2 tok/s here, wide enough to invert a ranking.

**Method deviations, stated in the section rather than buried:** the client is my own greedy streaming harness (max 1200 tokens), not `probe.py`, and the config is 262K/q8_0 rather than 131K/q4_0. Everything is one session against one server instance with only the spec flags varying, so the pairing holds. The n-max 2 and p-min 0.60 arms are medians of 3; spec-off, p-min 0.75/0.80 and n-max 8 are single screening runs, and the section says so. Happy to re-run the headline row under `probe.py` at 131K/q4_0 if you would rather the row be method-identical to the others — say the word and I will replace it.
