### PR TITLE
Add AMD Radeon AI PRO R9700 Vulkan community numbers and n-max 2/4 sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
+| AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
+\* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 
 ### A6000 48GB: n-max sweep
 
@@ -93,6 +95,17 @@ Same A6000, same config as the row above, `--spec-draft-n-max` swept 2-6. Overal
 | 6 | 58.6 | 84.3 | 37.4 | 58.6 | 0.23-0.84 |
 
 The overall peak is n-max 4 here, not 2 — the card has enough headroom to absorb the cost of deeper verification before the acceptance decay eats the win. Same shape as the 5090 sweep: the code prompts keep rising all the way up (84.3 at n-max 6), the prose prompt falls from the start (43.1 -> 37.4), and acceptance decays monotonically. Daily mixed use: 4, pure code sessions: 5-6, prose-heavy: 2.
+
+### AMD Radeon AI PRO R9700 32GB: n-max 2 versus 4
+
+Same R9700, same unsloth UD-Q4_K_XL model and serving config as the row above, at 262K context with q4_0 KV. Upstream `probe.py` unchanged: medians of three runs per prompt, thinking off. Draft acceptance is from the server log.
+
+| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|
+| 2 | 43.3 | 45.3 | **36.3** | 43.3 | 0.60-0.94 |
+| **4** | **47.4** | **75.5** | 33.3 | **47.4** | 0.28-0.90 |
+
+N-max 4 lifts the overall median another 9.5% over n-max 2, driven by a 66.7% jump on the Python prompt. Prose falls 8.3% as aggregate acceptance drops from 82.3% to 60.5%; prose-only acceptance is 29.4% at n-max 4. The speed shape supports n-max 4 as a code-specialized arm, while n-max 2 remains the mixed-workload default. Loaded VRAM: 22.53 GB spec-off, 24.55 GB at n-max 2, and 24.87 GB at n-max 4.
 
 ## License
 


### PR DESCRIPTION
Community run on an AMD Radeon AI PRO R9700 32GB using the repository's unchanged `probe.py` at commit `67c20536`.

## Headline

- Spec off: 27.0 tok/s overall median, 22.53 GB VRAM
- MTP n-max 2: 43.3 tok/s, +60.4%, 24.55 GB VRAM, acceptance 0.60-0.94
- MTP n-max 4: 47.4 tok/s, +75.6% versus baseline / +9.5% versus n-max 2, 24.87 GB VRAM, acceptance 0.28-0.90

## Method

Same live-server `probe.py` A/B as the README: warmup discarded, medians of three runs x three prompts, thinking off.

Configuration: Unsloth UD-Q4_K_XL, 262K context, q4_0 KV, llama.cpp b10433 (`9b05354ec`), Vulkan/RADV, `--parallel 1`.

## N-max shape

The n-max 4 result is sharply workload-dependent:

- Python: 45.3 -> 75.5 tok/s (+66.7%)
- Bash: 43.3 -> 47.4 tok/s (+9.5%)
- Prose: 36.3 -> 33.3 tok/s (-8.3%)

Aggregate acceptance drops from 82.3% at n-max 2 to 60.5% at n-max 4; prose-only acceptance is 29.4% at n-max 4. This host retains n-max 2 for mixed agent work and treats n-max 4 as a code-specialized arm.

## Change

README only: one community row, one configuration footnote, and the n-max 2/4 sweep.
