### PR TITLE
Add Ryzen AI Max+ 395 Windows Vulkan community results

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
+| Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
+\* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
 
 ### A6000 48GB: n-max sweep
 
@@ -93,6 +95,17 @@ Same A6000, same config as the row above, `--spec-draft-n-max` swept 2-6. Overal
 | 6 | 58.6 | 84.3 | 37.4 | 58.6 | 0.23-0.84 |
 
 The overall peak is n-max 4 here, not 2 — the card has enough headroom to absorb the cost of deeper verification before the acceptance decay eats the win. Same shape as the 5090 sweep: the code prompts keep rising all the way up (84.3 at n-max 6), the prose prompt falls from the start (43.1 -> 37.4), and acceptance decays monotonically. Daily mixed use: 4, pure code sessions: 5-6, prose-heavy: 2.
+
+### Ryzen AI Max+ 395 / Radeon 8060S: n-max 2 versus 4
+
+Same 64GB Strix Halo system, same unsloth UD-Q4_K_XL model and serving config as the row above: Windows Vulkan, 32K context, q8_0 KV, Flash Attention, batch 2048/512, and `--parallel 1`. Upstream `probe.py` was unchanged; all values are medians of three runs per prompt with thinking off. Acceptance is from the server log, excluding warmup.
+
+| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|
+| **2** | **23.7** | 25.2 | **19.1** | **23.7** | 0.52-0.94 (78.2% aggregate) |
+| 4 | 23.5 | **29.9** | 16.5 | 23.5 | 0.35-0.91 (65.8% aggregate) |
+
+MTP n-max 2 doubles the overall median versus the 11.5 tok/s spec-off control (+106%). N-max 4 is effectively flat overall (-0.8% versus n-max 2), but the workload split is sharp: Python rises 18.7% while prose falls 13.6%. This system keeps n-max 2 for mixed use and treats n-max 4 as a code-specialized option.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds the first Ryzen AI Max+ 395 / Radeon 8060S community A/B result, plus an n-max 2 versus 4 workload breakdown.

Headline result using the repository's unchanged `probe.py`:

- Spec off: 11.5 tok/s overall median
- MTP n-max 2: 23.7 tok/s, +106%, 78.2% aggregate acceptance
- MTP n-max 4: 23.5 tok/s, +104%, 65.8% aggregate acceptance

## Method

Same live-server paired A/B method as the README: warmup discarded, medians of three runs x three prompts, thinking off. Baseline and both MTP arms used the same server build, model, and serving configuration.

Configuration:

- AMD Ryzen AI Max+ 395 / Radeon 8060S, 64GB unified memory
- Windows build 26200, AMD driver 32.0.31035.1003
- llama.cpp b10437 (`16d222fc5`), official Windows Vulkan build
- Unsloth `UD-Q4_K_XL`, 32K context, q8_0 KV cache
- Flash Attention, batch 2048 / ubatch 512, `--parallel 1`
- `probe.py` unchanged at commit `67c2053`

## N-max shape

N-max 4 is effectively flat overall versus n-max 2 (-0.8%), but workload-sensitive:

- Python: 25.2 -> 29.9 tok/s (+18.7%)
- Prose: 19.1 -> 16.5 tok/s (-13.6%)
- Bash: 23.7 -> 23.5 tok/s (-0.8%)

This supports n-max 2 as the mixed-workload default on this bandwidth-limited APU, with n-max 4 as a code-specialized option.

## Validation

- `git diff --check`
- Three complete runs per prompt for baseline, n-max 2, and n-max 4
- Acceptance calculated from llama-server logs with warmup excluded
