### PR TITLE
Add RTX 5090 and RTX 3090 Ti 128K/256K results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Qwen3.8-27B MTP: the flag was free the whole time
 
-One llama.cpp flag unlocks +33% to +107% decode speed for Qwen3.8-27B on consumer GPUs, depending on the card. No new files, no conversion, no custom build. The MTP head already ships inside the GGUF you downloaded on launch night.
+One llama.cpp flag unlocks +33% to +110% decode speed for Qwen3.8-27B on consumer GPUs, depending on the card. No new files, no conversion, no custom build. The MTP head already ships inside the GGUF you downloaded on launch night.
 
-Opened hours after the Aug 14 2026 release. Within the first day the community grew it into a living record: **ten machines, eight contributors, every GPU vendor, and three tuning rules nobody knew at launch**, see [Community numbers](#community-numbers).
+Opened hours after the Aug 14 2026 release. Within the first day the community grew it into a living record: **twelve machines, nine contributors, every GPU vendor, and three tuning rules nobody knew at launch**, see [Community numbers](#community-numbers).
 
 ## The numbers
 
-The two founding rows, measured the night of the drop. The full living table (10 machines, all vendors) lives in [Community numbers](#community-numbers).
+The two founding rows, measured the night of the drop. The full living table (12 machines, all vendors) lives in [Community numbers](#community-numbers).
 
 | Card | Baseline | With the flag | Gain | Acceptance |
 |---|---|---|---|---|
@@ -84,6 +84,10 @@ Ran the A/B on your card? Open a PR and add a row.
 |---|---|---|---|---|---|
 | RTX 3090 24GB | 31.0 | 41.3 | 2 | 0.78 | [@sudoingX](https://x.com/sudoingX) |
 | RTX 5090 mobile 24GB | 36.7 | 50.9 | 2 | 0.79 | [@sudoingX](https://x.com/sudoingX) |
+| RTX 5090 32GB (Q6_K, 128K) | 61.9 | 130.0 | 2 | 0.52-0.95 | [@hypertectonic](https://github.com/hypertectonic) |
+| RTX 5090 32GB (Q6_K, 256K) | 62.0 | 121.7 | 2 | 0.50-0.95 | [@hypertectonic](https://github.com/hypertectonic) |
+| RTX 3090 Ti 24GB (Q4_K_M, 128K) | 42.0 | 60.9 | 2 | 0.47-0.93 | [@hypertectonic](https://github.com/hypertectonic) |
+| RTX 3090 Ti 24GB (Q4_K_M, 256K) | 41.2 | 61.4 | 2 | 0.55-0.94 | [@hypertectonic](https://github.com/hypertectonic) |
 | RTX 4090 24GB | 47.7 | 76.3 | 2 | 0.56 | [@Spadav_](https://x.com/Spadav_) |
 | RTX A6000 48GB (Ada) | 26.7 | 52.5 | 2 | 0.54-0.98 | [@lingster](https://github.com/lingster) |
 | RX 7900 XTX 24GB | 30.7 | 43.9 | 2 | 0.60-0.95 | [@Jqianggu](https://x.com/Jqianggu) |
@@ -101,6 +105,9 @@ Ran the A/B on your card? Open a PR and add a row.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
+\* RTX 5090 32GB rows: unsloth Q6_K, 128K/256K context, q4_0 KV cache, llama.cpp `62bf73d`, Windows/CUDA. Loaded VRAM was 24,441/27,385 MiB baseline and 25,797/29,381 MiB with spec. MTP gained 110.0% at 128K and 96.3% at 256K.
+\* RTX 3090 Ti rows: Q4_K_M, 128K/256K context, q4_0 KV cache, llama.cpp `62bf73d`, Linux/CUDA. Loaded VRAM was 18,842/21,786 MiB baseline and 20,134/23,718 MiB with spec. MTP gained 45.0% at 128K and 49.0% at 256K. The 256K MTP arm had 846 MiB free at load.
+\* RTX 5090 32GB and RTX 3090 Ti method: unchanged `probe.py` at commit `b299c0f`, three runs x three prompts, thinking off, warmup discarded. Baseline and MTP used the same model and serving config at each context. Only the MTP arm added `--spec-type draft-mtp --spec-draft-n-max 2`.
 
 ### A6000 48GB: n-max sweep
 


### PR DESCRIPTION
Adds paired A/B results for an RTX 5090 32GB and RTX 3090 Ti 24GB at both 128K and 256K context. Both cards used the recommended MTP2 flags.

| Card and context | Baseline | MTP2 | Gain | Acceptance | Loaded VRAM, baseline / MTP2 |
|---|---:|---:|---:|---:|---:|
| RTX 5090 32GB, Q6_K, 128K | 61.9 | 130.0 | +110.0% | 0.52-0.95, 79.7% aggregate | 24,441 / 25,797 MiB |
| RTX 5090 32GB, Q6_K, 256K | 62.0 | 121.7 | +96.3% | 0.50-0.95, 77.9% aggregate | 27,385 / 29,381 MiB |
| RTX 3090 Ti 24GB, Q4_K_M, 128K | 42.0 | 60.9 | +45.0% | 0.47-0.93, 78.5% aggregate | 18,842 / 20,134 MiB |
| RTX 3090 Ti 24GB, Q4_K_M, 256K | 41.2 | 61.4 | +49.0% | 0.55-0.94, 80.5% aggregate | 21,786 / 23,718 MiB |

## Method

- Unchanged upstream `probe.py` at commit `b299c0f`
- llama.cpp `62bf73d`
- Three runs for each of the three prompts, thinking off, warmup discarded
- Same model and serving configuration within each pair
- Full GPU offload, Flash Attention, q4_0 K/V cache, no mmproj, and `--parallel 1`
- Only the MTP arm added `--spec-type draft-mtp --spec-draft-n-max 2`

The probe prompts are shallow, so the 128K and 256K results measure the cost of keeping each context resident rather than generation after filling the full window. The RTX 3090 Ti 256K MTP arm completed the warmup and all nine measured requests without an OOM, but it had only 846 MiB free at load.

## Change

README only. Adds four community rows, configuration notes, and updates the machine, contributor, and maximum-gain totals.

## Validation

- `git diff --check`
- Signed commit verified against the approved Hypertectonic SSH signer
