### PR TITLE
Add Radeon 9060XT 16GB results

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
+| AMD Radeon 9060 XT 16 GB | 15.2 | 28.7 | 2 | 0.62-0.93 | [@kdrapel](https://github.com/kdrapel) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -101,6 +102,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
+\* Radeon 9060 XT 16 row: AtomicChat AD-IQ3_S_IQ3_XXS, 128k context, q4_0 KV cache — method: stock probe.py. Windows, ROCM
 
 ### A6000 48GB: n-max sweep
 
@@ -173,6 +175,17 @@ Same 64GB Strix Halo system, same unsloth UD-Q4_K_XL model and serving config as
 | 4 | 23.5 | **29.9** | 16.5 | 23.5 | 0.35-0.91 (65.8% aggregate) |
 
 MTP n-max 2 doubles the overall median versus the 11.5 tok/s spec-off control (+106%). N-max 4 is effectively flat overall (-0.8% versus n-max 2), but the workload split is sharp: Python rises 18.7% while prose falls 13.6%. This system keeps n-max 2 for mixed use and treats n-max 4 as a code-specialized option.
+
+### AMD Radeon 9060 XT 16 GB
+Single card. LLama compiled with ROCM 7.1 support (Vulkan slower with dense models). Model is AtomicChat IQ3_XXS (https://huggingface.co/AtomicChat/Qwen3.8-27B-GGUF). Upstream `probe.py` unchanged.
+
+| n-max | Overall | Acceptance |
+|---|---|---|
+| 2 | 28.7 | 0.62-0.93 |
+| 3 | 30.7 |  0.41-0.91 |
+| 4 | 30.9 |  0.29-0.93 |
+
+nb. made another sweeping test on MTP n-max with another benchmark and more complex task and n-max = 2 was the clear winner, performance was impacted with larger n-max, 2 is the sweet general spot
 
 ## License
 


### PR DESCRIPTION
Added Radeon 9060XT 16GB results. Windows, llama compiled with ROCM 7.1 support. Model is AtomicChat/Qwen3.8-27B IQ3_XXS

| n-max | Overall | Acceptance |
|---|---|---|
| 2 | 28.7 | 0.62-0.93 |
| 3 | 30.7 |  0.41-0.91 |
| 4 | 30.9 |  0.29-0.93 |
