### PR TITLE
Add RTX 3090 row on b10450: 41.3 -> 63.5 (+54%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
+| RTX 3090 24GB (b10450) | 41.3 | 63.5 | 2 | 0.69-0.87 | [@hauntedhost](https://github.com/hauntedhost) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -100,6 +101,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* RX 9070 row: two 16GB cards on one 31.84 GiB pool, Vulkan build b10426, unsloth UD-Q4_K_XL, **262K context**, q8_0 KV cache — 28.0 GiB across the pool with spec. Method differs from the rows above and is spelled out under the sweep below.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
+\* RTX 3090 b10450 row: unsloth Q4_K_M, 131K context, q8_0 KV cache, q8_0 draft KV, llama.cpp b10450 (master `ece963f41`), CUDA/Linux (CachyOS), froggeric fixed chat template, `--reasoning-format deepseek` — method: unchanged `probe.py`, three runs x three prompts, thinking off. Worth noting: the b10450 *baseline* (41.3) equals the original day-one with-flag number for this card — the young hybrid-attention kernels caught up upstream, and the flag now stacks on top of that (+54%).
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
 
 ### A6000 48GB: n-max sweep


### PR DESCRIPTION
Ran the paired A/B on a single RTX 3090 24GB (Linux/CachyOS, CUDA) on current master (b10450, `ece963f41`), stock `probe.py`, three runs x three prompts, thinking off.

| | tok/s |
|---|---|
| baseline (no spec) | 41.3 mean / 41.4 median |
| `--spec-type draft-mtp --spec-draft-n-max 2` | 63.5 mean / 65.0 median |

Acceptance 0.69-0.87 depending on prompt, mean draft length 2.4-2.75. Config: unsloth Q4_K_M, 131K context, q8_0 KV + q8_0 draft KV, froggeric fixed chat template, `--reasoning-format deepseek`.

The bit that seemed worth a footnote: the **baseline** on b10450 lands exactly where this card's day-one *with-flag* number was (41.3) — the hybrid-attention kernels caught up upstream, and the flag now stacks on top of the higher floor. Your "the floor should rise" caveat aged well.

Thanks for the repo and the probe — the whole thing took minutes to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)