### PR TITLE
docs: community row — GMK EVO-X2 (Ryzen AI Max+ 395, ROCm/HIP): draft-mtp n12 + stacked ngram-mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
+| GMK EVO-X2, Ryzen AI Max+ 395 (64GB unified, ROCm/HIP) | 10.5-11.1 | **21.4-22.2** / 59.7-64.0 stacked | 12 (+ ngram-mod, n-min 24) | 0.95-1.0 | [@KyaniteLabs](https://github.com/KyaniteLabs/qwen38-27b-strix-halo) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -101,6 +102,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
+\* GMK EVO-X2 row: Ryzen AI Max+ 395 (Strix Halo), 64GB unified memory, Linux, ROCm/HIP llama.cpp (gfx1151, ROCm 7.2.4), unsloth UD-Q4_K_XL, 96K context, f16 KV cache, `--parallel 1`, thinking off — 10.5-11.1 tok/s spec-off baseline; 21.4-22.2 tok/s with `--spec-draft-n-max 12` at 0.95-1.0 acceptance on the bench prompt (novel-traffic acceptance 0.345); stacking `--spec-type draft-mtp,ngram-mod --spec-ngram-mod-n-min 24` takes the streamed count bench to 59.7-64.0 cold and 148-163 warm on back-to-back repeats — the warm figure is an ngram repetition artifact on that prompt, not a general speedup (real novel traffic: prose 11-24, code 30-40 tok/s); production metric is time-per-task, 7.6-14.3 s per correct task across the thermal band. Method: streamed HTTP bench against a live llama-server (not `probe.py`), medians of 3+ runs; one-command reproducer: [bench.sh](https://github.com/KyaniteLabs/qwen38-27b-strix-halo/blob/main/bench.sh), full writeup: [one week with Qwen3.8-27B on Strix Halo](https://kyanitelabs.tech/blog/qwen-27b-strix-halo-one-week-local).
 
 ### A6000 48GB: n-max sweep
 


### PR DESCRIPTION
hi — thanks for this repo. The paired A/B discipline and the published n-max sweeps are what gave us the confidence to push the flag family much harder on this chip class, and the Strix Halo row from @shiwuxiu already put this APU on the map. This PR is **documentation only**: one row in the community table plus its config footnote, implementing the row proposed in #22.

### The row

| Card | Baseline | With flag | n-max | Acceptance |
|---|---|---|---|---|
| GMK EVO-X2, Ryzen AI Max+ 395 (64GB unified, ROCm/HIP) | 10.5-11.1 | **21.4-22.2** / 59.7-64.0 stacked | 12 (+ ngram-mod, n-min 24) | 0.95-1.0 |

Config: GMK EVO-X2 (Ryzen AI Max+ 395, Strix Halo), Linux, ROCm/HIP llama.cpp (gfx1151, ROCm 7.2.4), unsloth UD-Q4_K_XL, 96K context resident, f16 KV cache, `--parallel 1`, thinking off.

### What the numbers are, honestly

- **Spec-off baseline: 10.5-11.1 tok/s** (the ~178 GB/s bandwidth ceiling of this box). With `--spec-type draft-mtp --spec-draft-n-max 12`: **21.4-22.2 tok/s at 0.95-1.0 acceptance** on the bench prompt. Rule 1 (n-max sweet spot is card-dependent) is exactly what we measured: this APU absorbs n-max 12 where 24GB cards peak at 2-4 — acceptance on the count bench holds at ~0.96 mean at full depth. Caveat carried over from #22: acceptance on novel traffic is 0.345; deep drafting only pays when it hits.
- **The second multiplier was stacking, not depth**: `--spec-type draft-mtp,ngram-mod --spec-ngram-mod-n-min 24` takes the streamed count bench to **59.7-64.0 cold** and **148-163 warm on back-to-back repeats**. The warm figure is an ngram repetition artifact on that prompt and the footnote labels it as such — not a general speedup. Real novel traffic on the same stack: prose 11-24, code 30-40 tok/s. On genuinely repetitive work (agent tool loops, echoed-file rewrites) ngram is real: 72-133 tok/s.
- **We steer production by time-per-task, not tok/s**: 5 auto-graded tasks, 7.6-14.3 s per correct task across the thermal band on this chassis. That lens is also why the row stays UD-Q4_K_XL: all quants plateau ~22 tok/s with MTP, so quant quality is free (the Q3/Q2 rejections in our repo are time-per-task verdicts, not speed).

### Links (everything auditable)

- Reproduce in one command against a running server: https://github.com/KyaniteLabs/qwen38-27b-strix-halo (`./bench.sh`, prints a filled numbers block in the post-your-numbers shape)
- Full one-week writeup with the flag ladder and the dead ends (n-max 16 regresses code to 21.3 tok/s; n-min below 24 is flat): https://kyanitelabs.tech/blog/qwen-27b-strix-halo-one-week-local
- gfx1151/ROCm datapoints as a llama.cpp discussion: https://github.com/ggml-org/llama.cpp/discussions/27154
- One ROCm-vs-Vulkan datapoint for the footnotes, since the existing 395 row is Windows/Vulkan: same source and stack on Vulkan/RADV measured roughly half the spec-decode throughput and -36% prefill vs ROCm on this box.

Credit: measurements by Kyanite Labs (Simon Gonzalez de Cruz, assisted by GLM-5.3). Happy to reshape the row/footnote to whatever table format you settle on.

Closes #22.
