### PR TITLE
2x RTX 5060 Ti 16GB: two rows, and the split mode nobody is switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,18 +254,7 @@ Upstream says `--parallel 1` is required for spec-decode; the 3x3090 row reports
 
 **Speculative decoding is a single-stream optimisation.** At N=1 it is worth 1.70x. By N=2 the advantage is inside the noise, and at N=4 the two arms are indistinguishable (29.48 vs 29.24) — once the batch is full the GPU has real work queued and there is no idle verification capacity for the draft head to exploit. If you serve concurrent users, tune `--parallel` and skip the spec flags; if you are one person at a terminal, the flags are most of your speed.
 
-#### Power
-
-Sampled every 2s across the depth and concurrency arms, per GPU:
-
-| arm | GPU0 peak / mean | GPU1 peak / mean | combined peak / mean |
-|---|---|---|---|
-| depth, spec off | 139 W / 106 W | 154 W / 116 W | 293 W / 222 W |
-| depth, MTP n-3 | 127 W / 98 W | 142 W / 108 W | 268 W / 205 W |
-| concurrency, spec off | 147 W / 95 W | 158 W / 104 W | 305 W / 199 W |
-| concurrency, MTP n-3 | 129 W / 83 W | 138 W / 91 W | 267 W / 174 W |
-
-The cards are rated 180 W each and never approach it — this workload is memory-bound, not compute-bound, which is the same reason tensor-split helps so much. MTP arms draw *less* power than their controls while producing more tokens.
+One side effect worth a line: across every arm the MTP runs drew *less* power than their spec-off controls while producing more tokens — combined peak 268 W vs 293 W on the depth sweep, 267 W vs 305 W under concurrency. The draft head is not buying speed with watts.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,13 @@ Same box, same GGUF, same serve config throughout — only `--split-mode` and th
 | `layer` | n-max 4 | 45.2 | 60.1 | 32.1 | 45.2 | 0.39-0.72 |
 | `tensor` | off | **37.1** | 37.1 | 37.3 | 37.0 | — |
 | `tensor` | n-max 2 | 65.9 | 70.6 | 51.4 | 65.9 | 0.51-0.88 |
-| `tensor` | n-max 3 | **69.3** | 78.7 | 53.6 | 69.3 | 0.38-0.74 |
+| `tensor` | n-max 3 | 69.3 | 78.7 | 53.6 | 69.3 | 0.38-0.74 |
+| `tensor` | n-max 4 | **71.3** | 83.4 | 47.6 | 71.3 | 0.35-0.70 |
+| `tensor` | n-max 5 | 67.1 | | | | |
+| `tensor` | n-max 6 | 56.2 | | | | |
+| `tensor` | n-max 8 | 59.7 | | | | |
+| `tensor` | n-max 4, `p-min 0.60` | 46.2 | 71.6 | 23.3 | 46.2 | 0.41-0.82 |
+| `tensor` | n-max 6, `p-min 0.60` | 45.4 | 65.8 | 24.3 | 45.4 | 0.56-0.85 |
 | `row` | off | fails to load | | | | |
 
 **The default split mode costs more than the flag gains.** `--split-mode layer` splits layers across cards, so at batch 1 there is nothing to pipeline: GPU0 computes while GPU1 idles and the pair decodes at single-card bandwidth. `--split-mode tensor` splits each matmul instead, both cards read weights at once, and the baseline goes 22.1 -> 37.1 (**+68%**) before any spec flag is involved. That is a larger free win than MTP gives on a 24GB single card.
@@ -203,7 +209,13 @@ Two things worth knowing before you try this:
 - `--split-mode row` refuses to load — `device CUDA0 does not support split buffers`. `tensor` is the mode that works.
 - `--split-mode tensor` skips the auto-fit pass. `llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort` is a warning, not an error, and the server starts anyway with whatever `-c` you passed. Check `n_ctx_slot` in the log before comparing against a `layer` run, or you may be comparing two different context sizes. Both arms above were verified at `n_ctx_slot = 131072`.
 
-**The n-max sweet spot lands on 3 for a 32GB pool**, under both split modes — between the 24GB cards that peak at 2 and the 48GB A6000 that peaks at 4, which is the shape rule 1 predicts. Everything else matches the other sweeps too: code prompts keep climbing (60.1 at n-max 4 under `layer`, 78.7 at n-max 3 under `tensor`), prose falls from the start, acceptance decays monotonically.
+**The n-max sweet spot moves with the split mode, not just the VRAM pool.** Same box, same 32GB, same everything else: `layer` peaks at n-max 3 (47.5, falling to 45.2 at 4) while `tensor` peaks at n-max 4 (71.3), holds 67.1 at 5 and only collapses at 6. Rule 1 says the sweet spot is card-dependent — this says it is also *topology*-dependent, because tensor-split makes each verification step cheaper, so the pool can absorb a deeper draft before acceptance decay eats the win. If you switch split mode, re-sweep n-max; the old optimum does not carry over.
+
+Everything else matches the other sweeps: code prompts keep climbing (83.4 at n-max 4 under `tensor`), prose falls from the start (53.6 at n-max 3 down to 47.6 at 4), acceptance decays monotonically.
+
+**`--spec-draft-p-min` is a large net loss here**, which is the opposite of what it does on the RX 9070 pair. Gating n-max 4 at 0.60 drops the overall median from 71.3 to 46.2 — and it does so *while raising* acceptance from 0.35-0.70 to 0.41-0.82. The gate is refusing drafts that would have been accepted; the prose prompt takes the worst of it (53.6 → 23.3). Both rigs are 2x16GB, so the knob clearly does not generalize across backends — worth sweeping rather than adopting.
+
+**The gain does not scale with output length on this box.** Running the same two arms at 4096 tokens instead of 400 (probe.py with only `MAX_TOKENS` changed): baseline 37.1, MTP n-max 3 68.7 — a 1.85x ratio against 1.87x at 400 tokens. Rule 3 holds where spec overhead dominates short generations; here the tensor-split baseline is bandwidth-bound and stable, so the full gain is already present at 400 tokens and there is nothing left to recover at 4096.
 
 `llama-bench` on the same box as a cross-check, `-fa 1 -ctk q4_0 -ctv q4_0`:
 
@@ -213,6 +225,47 @@ Two things worth knowing before you try this:
 | `tensor` | 1028.04 ± 2.69 | **38.37 ± 0.26** | 550.86 ± 0.77 |
 
 `llama-bench` puts the decode gain at +70%, `probe.py` at +68% — two different tools, two different prompt sets, same answer. Prefill moves only +11%, which is the expected shape: prompt processing is compute-bound and already batched, so layer-split leaves both cards reasonably busy; decode at batch 1 is where the serialization actually bites.
+
+#### Decode against prompt depth
+
+`probe.py` runs at near-zero context, which is the easiest case for any spec-decode setup. Both arms re-measured under `-sm tensor` with a filler prompt sized against the server's own `/tokenize` endpoint, so the depths are token-exact rather than a chars-per-token guess. TTFT excluded from the decode rate, as in `probe.py`.
+
+| prompt tokens | spec off: TTFT | prefill t/s | decode t/s | MTP n-3: TTFT | prefill t/s | decode t/s | ratio |
+|---|---|---|---|---|---|---|---|
+| 4,075 | 2.59 s | 1,572 | 36.24 | 2.80 s | 1,454 | 56.05 | 1.55x |
+| 16,255 | 7.57 s | 2,148 | 34.53 | 8.25 s | 1,970 | 53.27 | 1.54x |
+| 32,467 | 10.51 s | **3,089** | 32.38 | 11.53 s | 2,817 | 50.79 | 1.57x |
+| 64,891 | 22.35 s | 2,904 | 28.73 | 24.50 s | 2,649 | 56.43 | 1.96x |
+| 129,781 | 52.33 s | 2,480 | 23.70 | 58.11 s | 2,233 | 46.34 | 1.96x |
+
+**The flag matters more the deeper you go, not less.** The unassisted arm loses 35% of its decode rate between 4K and 128K (36.24 → 23.70); the MTP arm loses 17% (56.05 → 46.34). At 128K of resident context this pair still generates at 46 tok/s.
+
+Two caveats on this table. The 64K and 128K rows generated only ~42 tokens before the model stopped, so those decode figures rest on a much smaller sample than the shallower rows — treat the 1.96x as indicative, not settled. And prefill peaking mid-sweep (3,089 t/s at 32K, lower at both 4K and 128K) is the usual batching-vs-attention-cost curve, not a measurement error.
+
+#### Concurrency, and whether MTP survives `--parallel 4`
+
+Upstream says `--parallel 1` is required for spec-decode; the 3x3090 row reports it was not required on that host. On this one **the server starts and serves correctly with `--parallel 4` and MTP together**. Whether it *helps* is a different question. 16K prompts, `-sm tensor`, per-stream is the median stream, aggregate is total generated tokens over wall clock including prefill:
+
+| N | spec off: per-stream | aggregate | MTP n-3: per-stream | aggregate |
+|---|---|---|---|---|
+| 1 | 34.19 | 6.91 | **57.99** | 10.72 |
+| 2 | 19.32 | 18.53 | 20.94 | 16.34 |
+| 4 | 19.13 | **29.48** | 19.21 | **29.24** |
+
+**Speculative decoding is a single-stream optimisation.** At N=1 it is worth 1.70x. By N=2 the advantage is inside the noise, and at N=4 the two arms are indistinguishable (29.48 vs 29.24) — once the batch is full the GPU has real work queued and there is no idle verification capacity for the draft head to exploit. If you serve concurrent users, tune `--parallel` and skip the spec flags; if you are one person at a terminal, the flags are most of your speed.
+
+#### Power
+
+Sampled every 2s across the depth and concurrency arms, per GPU:
+
+| arm | GPU0 peak / mean | GPU1 peak / mean | combined peak / mean |
+|---|---|---|---|
+| depth, spec off | 139 W / 106 W | 154 W / 116 W | 293 W / 222 W |
+| depth, MTP n-3 | 127 W / 98 W | 142 W / 108 W | 268 W / 205 W |
+| concurrency, spec off | 147 W / 95 W | 158 W / 104 W | 305 W / 199 W |
+| concurrency, MTP n-3 | 129 W / 83 W | 138 W / 91 W | 267 W / 174 W |
+
+The cards are rated 180 W each and never approach it — this workload is memory-bound, not compute-bound, which is the same reason tensor-split helps so much. MTP arms draw *less* power than their controls while producing more tokens.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
+| 2× RTX 5060 Ti 16GB (PP, default `-sm layer`) | 22.1 | 42.8 | 2 | 0.53-0.94 | [@Jackwwg83](https://github.com/Jackwwg83) |
+| 2× RTX 5060 Ti 16GB (TP, `-sm tensor`) | 37.1 | 65.9 | 2 | 0.51-0.88 | [@Jackwwg83](https://github.com/Jackwwg83) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -101,6 +103,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
+\* 2× RTX 5060 Ti rows: unsloth UD-Q4_K_XL (sha256 `bee238bb…1372`), 131K context, q4_0 KV cache, llama.cpp built from source at commit `ece963f4` with `-DCMAKE_CUDA_ARCHITECTURES=120`, CUDA 13.0 / driver 580.173.02, PCIe 3.0 x8, `PHB` topology (no P2P). Method: unchanged `probe.py`, three runs x three prompts, thinking off. VRAM: PP 21.7 GB baseline / 23.0 GB with spec; TP 20.9 GB / 22.1 GB. The 16.68 GiB of weights do not fit one 16GB card, so two cards is the floor on this box — the split-mode choice is not optional here, which is what makes the two rows worth reading side by side. Both rows verified at `n_ctx_slot = 131072`. Details under the sweep below.
 
 ### A6000 48GB: n-max sweep
 
@@ -173,6 +176,43 @@ Same 64GB Strix Halo system, same unsloth UD-Q4_K_XL model and serving config as
 | 4 | 23.5 | **29.9** | 16.5 | 23.5 | 0.35-0.91 (65.8% aggregate) |
 
 MTP n-max 2 doubles the overall median versus the 11.5 tok/s spec-off control (+106%). N-max 4 is effectively flat overall (-0.8% versus n-max 2), but the workload split is sharp: Python rises 18.7% while prose falls 13.6%. This system keeps n-max 2 for mixed use and treats n-max 4 as a code-specialized option.
+
+### 2× RTX 5060 Ti 16GB: on a multi-GPU box the split mode is worth more than the flag
+
+Same box, same GGUF, same serve config throughout — only `--split-mode` and the spec flags change. Stock `probe.py`, medians of three runs x three prompts, thinking off. Acceptance from the server log.
+
+| split mode | spec | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|---|
+| `layer` (default) | off | 22.1 | 22.0 | 22.1 | 22.0 | — |
+| `layer` | n-max 2 | 42.8 | 47.3 | 34.4 | 42.8 | 0.53-0.94 |
+| `layer` | n-max 3 | **47.5** | 54.0 | 35.4 | 47.5 | 0.48-0.75 |
+| `layer` | n-max 4 | 45.2 | 60.1 | 32.1 | 45.2 | 0.39-0.72 |
+| `tensor` | off | **37.1** | 37.1 | 37.3 | 37.0 | — |
+| `tensor` | n-max 2 | 65.9 | 70.6 | 51.4 | 65.9 | 0.51-0.88 |
+| `tensor` | n-max 3 | **69.3** | 78.7 | 53.6 | 69.3 | 0.38-0.74 |
+| `row` | off | fails to load | | | | |
+
+**The default split mode costs more than the flag gains.** `--split-mode layer` splits layers across cards, so at batch 1 there is nothing to pipeline: GPU0 computes while GPU1 idles and the pair decodes at single-card bandwidth. `--split-mode tensor` splits each matmul instead, both cards read weights at once, and the baseline goes 22.1 -> 37.1 (**+68%**) before any spec flag is involved. That is a larger free win than MTP gives on a 24GB single card.
+
+The two levers stack cleanly: **22.1 -> 69.3, a 3.14x end-to-end gain from two flags, neither of which costs anything.** Worth spelling out because `layer` is the default, so a two-card owner who follows the launch command verbatim measures 42.8 and stops there.
+
+The all-reduce is not free but it is cheaper than expected here: these are GeForce cards with P2P disabled, on PCIe 3.0 x8 with a `PHB` topology, so every reduction crosses host memory. Ideal scaling would put TP at 44.2 (2x the 22.1 single-card-equivalent); the measured 37.1 says the reduction costs about 16%. A host with working P2P should keep more of it.
+
+Two things worth knowing before you try this:
+
+- `--split-mode row` refuses to load — `device CUDA0 does not support split buffers`. `tensor` is the mode that works.
+- `--split-mode tensor` skips the auto-fit pass. `llama_params_fit is not implemented for SPLIT_MODE_TENSOR, abort` is a warning, not an error, and the server starts anyway with whatever `-c` you passed. Check `n_ctx_slot` in the log before comparing against a `layer` run, or you may be comparing two different context sizes. Both arms above were verified at `n_ctx_slot = 131072`.
+
+**The n-max sweet spot lands on 3 for a 32GB pool**, under both split modes — between the 24GB cards that peak at 2 and the 48GB A6000 that peaks at 4, which is the shape rule 1 predicts. Everything else matches the other sweeps too: code prompts keep climbing (60.1 at n-max 4 under `layer`, 78.7 at n-max 3 under `tensor`), prose falls from the start, acceptance decays monotonically.
+
+`llama-bench` on the same box as a cross-check, `-fa 1 -ctk q4_0 -ctv q4_0`:
+
+| split mode | pp512 | tg128 | pp4096+tg128 |
+|---|---|---|---|
+| `layer` | 926.96 ± 18.81 | 22.58 ± 0.02 | 482.17 ± 0.22 |
+| `tensor` | 1028.04 ± 2.69 | **38.37 ± 0.26** | 550.86 ± 0.77 |
+
+`llama-bench` puts the decode gain at +70%, `probe.py` at +68% — two different tools, two different prompt sets, same answer. Prefill moves only +11%, which is the expected shape: prompt processing is compute-bound and already batched, so layer-split leaves both cards reasonably busy; decode at batch 1 is where the serialization actually bites.
 
 ## License
 


### PR DESCRIPTION
Ran the paired A/B on 2× RTX 5060 Ti 16GB (32GB pool). Two rows rather than one, because the interesting result is the gap between them.

| split mode | baseline | n-max 2 |
|---|---|---|
| `layer` (default) | 22.1 | 42.8 |
| `tensor` | 37.1 | 65.9 |

**On a multi-GPU box the default split mode costs more than the flag gains.** `-sm layer` splits layers, so at batch 1 there is nothing to pipeline — one card computes while the other idles and the pair decodes at single-card bandwidth. `-sm tensor` splits each matmul, both cards read weights at once, and the baseline moves 22.1 → 37.1 (+68%) before any spec flag is involved. That is a bigger free win than MTP gives on a 24GB single card, and `layer` is the default, so a two-card owner following the launch command verbatim measures 42.8 and stops.

The two levers stack: **22.1 → 69.3, 3.14×, both flags free.**

Also in the new section:

- **n-max peaks at 3 for a 32GB pool**, under both split modes — sits between the 24GB cards (2) and the 48GB A6000 (4), which is the shape rule 1 predicts. Third point on that line.
- `-sm row` refuses to load: `device CUDA0 does not support split buffers`.
- `-sm tensor` skips the auto-fit pass — `llama_params_fit is not implemented for SPLIT_MODE_TENSOR` is a warning, not an error, and the server starts with whatever `-c` you gave it. Easy way to accidentally compare two different context sizes. Both arms verified at `n_ctx_slot = 131072`.
- `llama-bench` cross-check agrees: +70% decode against the +68% from `probe.py`. Prefill only +11%, which is the expected shape — prompt processing is compute-bound and already batched.

Method: unchanged `probe.py`, three runs × three prompts, thinking off, medians. unsloth UD-Q4_K_XL (sha256 `bee238bb…1372`), 131K context, q4_0 KV, llama.cpp from source at `ece963f4` with `-DCMAKE_CUDA_ARCHITECTURES=120`, CUDA 13.0 / driver 580.173.02, PCIe 3.0 x8, `PHB` topology so no P2P. The 16.68 GiB of weights do not fit one 16GB card, so two cards is the floor on this box — the split-mode choice is not optional here.

One arm I deliberately left out of the writeup: q4_0 draft KV (`-ctkd/-ctvd`) measured 42.8 → 44.0, inside the ±2 tok/s noise band you already flagged, so I am not claiming it as a finding. On a 32GB pool it buys nothing; its value is capacity on a 24GB card.
