### PR TITLE
Add RTX 5090 32GB (desktop): 69.3 → 129.1 (+86%) ungated at n-max 4 — third rig where the p-min rule inverts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
-| RTX 5090 32GB (desktop) | 69.3 | 123.9 | 4 | 0.71-0.74 | [@paulomcg](https://github.com/paulomcg) |
+| RTX 5090 32GB (desktop) | 69.3 | 132.7 | 4 | 0.51 | [@paulomcg](https://github.com/paulomcg) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -101,7 +101,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* RX 9070 row: two 16GB cards on one 31.84 GiB pool, Vulkan build b10426, unsloth UD-Q4_K_XL, **262K context**, q8_0 KV cache — 28.0 GiB across the pool with spec. Method differs from the rows above and is spelled out under the sweep below.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
-\* RTX 5090 32GB row: unsloth UD-Q4_K_XL, **192K context**, q8_0 KV cache, mmproj loaded (vision, `--image-min-tokens 1024`), llama-swap `unified-cuda-2026-08-14`, Linux/CUDA — 26.5 GB VRAM baseline, 28.5 GB with spec. Uses **`--spec-draft-p-min 0.60`**, the second rig in this table to run the gate. Both arms at `--parallel 1` so only the spec flags differ. Method: stock `probe.py`, medians of three runs x three prompts, thinking off. n-max sweep at p-min 0.60 below.
+\* RTX 5090 32GB row: unsloth UD-Q4_K_XL, **192K context**, q8_0 KV cache, mmproj loaded (vision, `--image-min-tokens 1024`), llama-swap `unified-cuda-2026-08-14`, Linux/CUDA — 26.5 GB VRAM baseline, 28.5 GB with spec. **Ungated** — see the p-min A/B below. Both arms at `--parallel 1` so only the spec flags differ. Method: stock `probe.py`, medians of three runs x three prompts, thinking off. n-max sweep at p-min 0.60 below.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
 
 ### A6000 48GB: n-max sweep
@@ -154,30 +154,43 @@ Two things this rig says that the NVIDIA rows do not:
 
 Method note, since it is not the repo's: numbers come from a local greedy streaming harness (max 1200 tokens) rather than `probe.py`, all in one session against one server instance with only the spec flags varying. The n-max 2 and p-min 0.60 arms are medians of 3; the spec-off, p-min 0.75/0.80 and n-max 8 arms are single screening runs. Treat the sweep as a shape, and the two headline arms as measurements.
 
-### RTX 5090 32GB (desktop): n-max sweep at `--spec-draft-p-min 0.60`
+### RTX 5090 32GB (desktop): the p-min gate is inverted here too
 
-Same card and config as the row above, `--spec-draft-n-max` swept 4-6, all arms
-gated at p-min 0.60. Overall and per-prompt `probe.py` medians (tok/s), draft
-acceptance from the server log:
+Ran the gate A/B at n-max 4 on the deployed config (224K, q8_0 KV, two slots).
+`probe.py` medians of three runs x three prompts, thinking off, only the p-min
+flag varying:
 
-| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+| config | Overall mean | Overall median | P1 code (py) | P2 prose (mmap) | Acceptance |
 |---|---|---|---|---|---|
-| **4** | **123.9** | 150.7 | 98.0 | 123.9 | 0.73-0.74 |
-| 5 | 126.9 | 159.6 | 92.0 | 126.9 | 0.72-0.74 |
-| 6 | 120.5 | 146.6 | 96.5 | 120.5 | 0.61-0.67 |
+| n-max 4, `--spec-draft-p-min 0.60` | 127.3 | 126.9 | 151.8 | 99.3 | 0.75 |
+| **n-max 4, ungated** | **132.7** | 126.7 | **167.8** | 100.3 | 0.51 |
+| n-max 6, ungated | 114.6 | 113.0 | 157.4 | 79.3 | 0.46 |
 
-Same shape as the A6000 and 3x3090 sweeps: code climbs, prose falls, acceptance
-decays. 4 and 5 are inside the noise band on overall median (means are 125.4 vs
-125.3); 4 ships here because prose is meaningfully better (98.0 vs 92.0) and
-this box serves agents that write far more prose than code.
+Ungated wins by 4.2% on the mean and 10.5% on the code prompt; prose and the
+overall median are flat. Smaller than the 26% loss @taco-devs measured in the
+0.60-0.70 band, but the same direction — and @jcr211's NVFP4 rig lands the same
+way, with gated n-max 4 (103.9) losing to ungated n-max 3 (108.7).
+
+That is three independent RTX 5090s where **rule 2 inverts**. The gate helps the
+bandwidth-starved cards it was found on and costs throughput on cards where
+verification is close to free. Worth treating as card-class-dependent rather
+than a universal default.
+
+**Acceptance is a vanity metric on this class of card.** Gating raised it from
+0.51 to 0.75 while throughput went *down*. Tuning for acceptance picks the
+slower configuration.
+
+Depth optimum here is 4 ungated; 6 is clearly worse, with prose collapsing from
+100.3 to 79.3.
 
 **A `--parallel` warning worth its own line.** The README says `--parallel 1` is
-required, and it is — but the cost of getting it wrong is not just an unsupported
-config, it is a corrupted baseline. This box ran `--parallel 2` before the sweep
-and measured 55.4 tok/s unassisted. At `--parallel 1`, same everything else, the
-unassisted number is 69.3. **`--parallel 2` alone costs ~20% of single-stream
-decode.** Pairing an MTP arm against a `--parallel 2` baseline reads as +124%
-when the honest figure is +79%. Measure both arms at `--parallel 1`.
+required, and it is — but the cost of getting it wrong is not just an
+unsupported config, it is a corrupted baseline. This box ran `--parallel 2`
+before the sweep and measured 55.4 tok/s unassisted. At `--parallel 1`, same
+everything else, the unassisted number is 69.3. **`--parallel 2` alone costs
+~20% of single-stream decode.** Pairing an MTP arm against a `--parallel 2`
+baseline reads as +124% when the honest figure is +93%. Measure both arms at
+`--parallel 1`.
 
 ### AMD Radeon AI PRO R9700 32GB: n-max 2 versus 4
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
+| RTX 5090 32GB (desktop) | 69.3 | 123.9 | 4 | 0.71-0.74 | [@paulomcg](https://github.com/paulomcg) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -100,6 +101,7 @@ Ran the A/B on your card? Open a PR and add a row.
 \* RX 9070 row: two 16GB cards on one 31.84 GiB pool, Vulkan build b10426, unsloth UD-Q4_K_XL, **262K context**, q8_0 KV cache — 28.0 GiB across the pool with spec. Method differs from the rows above and is spelled out under the sweep below.
 \* R9700 row: unsloth UD-Q4_K_XL, 262K context, q4_0 KV cache, llama.cpp b10433, Vulkan/RADV — 22.53 GB VRAM baseline, 24.55 GB with n-max 2. Method: unchanged `probe.py` at commit `67c20536`, three runs x three prompts, thinking off.
 \* Ryzen AI Max+ 395 row: 64GB unified memory, unsloth UD-Q4_K_XL, 32K context, q8_0 KV cache, llama.cpp b10437, Windows build 26200, Vulkan with AMD driver 32.0.31035.1003. Method: unchanged `probe.py` at commit `67c2053`, three runs x three prompts, thinking off.
+\* RTX 5090 32GB row: unsloth UD-Q4_K_XL, **192K context**, q8_0 KV cache, mmproj loaded (vision, `--image-min-tokens 1024`), llama-swap `unified-cuda-2026-08-14`, Linux/CUDA — 26.5 GB VRAM baseline, 28.5 GB with spec. Uses **`--spec-draft-p-min 0.60`**, the second rig in this table to run the gate. Both arms at `--parallel 1` so only the spec flags differ. Method: stock `probe.py`, medians of three runs x three prompts, thinking off. n-max sweep at p-min 0.60 below.
 \* RTX 4090 Spadav_ row: unsloth Q4_K_M, 200K context, q4_0 KV cache, q8_0 draft KV, mmproj loaded (888MB on GPU) — method: stock probe.py + 4096-token curl (MTP crossover: overhead dominates at ≤400 tokens, +60% at 4096 tokens).
 
 ### A6000 48GB: n-max sweep
@@ -151,6 +153,31 @@ Two things this rig says that the NVIDIA rows do not:
 - **N=1 crowned the wrong arm.** A single-run screen put p-min 0.75 on top; medians of 3 flipped the winner to 0.60. The noise band here is around +/-2 tok/s, which is wide enough to invert a ranking. Do reps before you deploy a config.
 
 Method note, since it is not the repo's: numbers come from a local greedy streaming harness (max 1200 tokens) rather than `probe.py`, all in one session against one server instance with only the spec flags varying. The n-max 2 and p-min 0.60 arms are medians of 3; the spec-off, p-min 0.75/0.80 and n-max 8 arms are single screening runs. Treat the sweep as a shape, and the two headline arms as measurements.
+
+### RTX 5090 32GB (desktop): n-max sweep at `--spec-draft-p-min 0.60`
+
+Same card and config as the row above, `--spec-draft-n-max` swept 4-6, all arms
+gated at p-min 0.60. Overall and per-prompt `probe.py` medians (tok/s), draft
+acceptance from the server log:
+
+| n-max | Overall | P1 code (py) | P2 prose (mmap) | P3 code (bash) | Acceptance |
+|---|---|---|---|---|---|
+| **4** | **123.9** | 150.7 | 98.0 | 123.9 | 0.73-0.74 |
+| 5 | 126.9 | 159.6 | 92.0 | 126.9 | 0.72-0.74 |
+| 6 | 120.5 | 146.6 | 96.5 | 120.5 | 0.61-0.67 |
+
+Same shape as the A6000 and 3x3090 sweeps: code climbs, prose falls, acceptance
+decays. 4 and 5 are inside the noise band on overall median (means are 125.4 vs
+125.3); 4 ships here because prose is meaningfully better (98.0 vs 92.0) and
+this box serves agents that write far more prose than code.
+
+**A `--parallel` warning worth its own line.** The README says `--parallel 1` is
+required, and it is — but the cost of getting it wrong is not just an unsupported
+config, it is a corrupted baseline. This box ran `--parallel 2` before the sweep
+and measured 55.4 tok/s unassisted. At `--parallel 1`, same everything else, the
+unassisted number is 69.3. **`--parallel 2` alone costs ~20% of single-stream
+decode.** Pairing an MTP arm against a `--parallel 2` baseline reads as +124%
+when the honest figure is +79%. Measure both arms at `--parallel 1`.
 
 ### AMD Radeon AI PRO R9700 32GB: n-max 2 versus 4
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | 2x RX 9070 16GB (Vulkan) | 22.1 | 41.6 | 2 | 0.73 | [@tomertec](https://github.com/tomertec) |
 | AMD Radeon AI PRO R9700 32GB | 27.0 | 43.3 | 2 | 0.60-0.94 | [@ajnytebot](https://github.com/ajnytebot) |
 | Ryzen AI Max+ 395 / Radeon 8060S | 11.5 | 23.7 | 2 | 0.52-0.94 | [@shiwuxiu](https://github.com/shiwuxiu) |
-| RTX 5090 32GB (desktop) | 69.3 | 132.7 | 4 | 0.51 | [@paulomcg](https://github.com/paulomcg) |
+| RTX 5090 32GB (desktop) | 69.3 | 129.1 | 4 | 0.55 | [@paulomcg](https://github.com/paulomcg) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -156,41 +156,41 @@ Method note, since it is not the repo's: numbers come from a local greedy stream
 
 ### RTX 5090 32GB (desktop): the p-min gate is inverted here too
 
-Ran the gate A/B at n-max 4 on the deployed config (224K, q8_0 KV, two slots).
-`probe.py` medians of three runs x three prompts, thinking off, only the p-min
-flag varying:
+Gate A/B at n-max 4. All three arms at 192K, q8_0 KV, `--parallel 1` — only the
+spec flags vary, so these are directly comparable to the row's baseline.
+`probe.py` medians of three runs x three prompts, thinking off:
 
-| config | Overall mean | Overall median | P1 code (py) | P2 prose (mmap) | Acceptance |
+| config | Overall median | Overall mean | P1 code (py) | P2 prose (mmap) | Acceptance |
 |---|---|---|---|---|---|
-| n-max 4, `--spec-draft-p-min 0.60` | 127.3 | 126.9 | 151.8 | 99.3 | 0.75 |
-| **n-max 4, ungated** | **132.7** | 126.7 | **167.8** | 100.3 | 0.51 |
-| n-max 6, ungated | 114.6 | 113.0 | 157.4 | 79.3 | 0.46 |
+| spec off | 69.3 | 69.3 | 69.3 | 69.2 | — |
+| n-max 4, `--spec-draft-p-min 0.60` | 123.9 | 125.4 | 150.7 | 98.0 | 0.73 |
+| **n-max 4, ungated** | **129.1** | 131.6 | 157.4 | 109.1 | 0.55 |
 
-Ungated wins by 4.2% on the mean and 10.5% on the code prompt; prose and the
-overall median are flat. Smaller than the 26% loss @taco-devs measured in the
-0.60-0.70 band, but the same direction — and @jcr211's NVFP4 rig lands the same
-way, with gated n-max 4 (103.9) losing to ungated n-max 3 (108.7).
+Ungated wins on every prompt: +4.2% overall median, +4.4% on code, +11.3% on
+prose. Smaller than the 26% loss @taco-devs measured in the 0.60-0.70 band, but
+the same direction — and @jcr211's NVFP4 rig lands the same way, with gated
+n-max 4 (103.9) below ungated n-max 3 (108.7).
 
-That is three independent RTX 5090s where **rule 2 inverts**. The gate helps the
-bandwidth-starved cards it was found on and costs throughput on cards where
-verification is close to free. Worth treating as card-class-dependent rather
-than a universal default.
+That is three independent RTX 5090s, on three different quants, where **rule 2
+inverts**. The gate helps the bandwidth-starved cards it was found on; where
+verification is close to free it converts skipped drafts into plain decode
+rounds. Worth treating as card-class-dependent rather than a default.
 
-**Acceptance is a vanity metric on this class of card.** Gating raised it from
-0.51 to 0.75 while throughput went *down*. Tuning for acceptance picks the
+**Acceptance is a vanity metric on this class of card.** Gating moved it from
+0.55 to 0.73 while throughput went *down*. Tuning for acceptance picks the
 slower configuration.
 
-Depth optimum here is 4 ungated; 6 is clearly worse, with prose collapsing from
+Depth optimum here is 4. A separate ungated sweep at 224K with two slots put
+n-max 6 at 113.0 median against 126.7 for n-max 4, with prose collapsing from
 100.3 to 79.3.
 
 **A `--parallel` warning worth its own line.** The README says `--parallel 1` is
 required, and it is — but the cost of getting it wrong is not just an
-unsupported config, it is a corrupted baseline. This box ran `--parallel 2`
-before the sweep and measured 55.4 tok/s unassisted. At `--parallel 1`, same
-everything else, the unassisted number is 69.3. **`--parallel 2` alone costs
-~20% of single-stream decode.** Pairing an MTP arm against a `--parallel 2`
-baseline reads as +124% when the honest figure is +93%. Measure both arms at
-`--parallel 1`.
+unsupported config, it is a corrupted baseline. This box measured 55.4 tok/s
+unassisted at `--parallel 2`; at `--parallel 1`, same everything else, it is
+69.3. **`--parallel 2` alone costs ~20% of single-stream decode.** Pairing an
+MTP arm against a `--parallel 2` baseline reads as +133% when the honest figure
+is +86%. Measure both arms at `--parallel 1`.
 
 ### AMD Radeon AI PRO R9700 32GB: n-max 2 versus 4
 


### PR DESCRIPTION
Desktop RTX 5090 32GB. unsloth UD-Q4_K_XL, 192K context, q8_0 KV, mmproj loaded (vision), llama-swap `unified-cuda-2026-08-14`, Linux/CUDA. Stock `probe.py`, medians of 3 runs × 3 prompts, thinking off.

| Card | Baseline | With flag | n-max | Acceptance |
|---|---|---|---|---|
| RTX 5090 32GB (desktop) | 69.3 | **129.1** | 4 (ungated) | 0.55 |

## Rule 2 inverts here, and that now looks card-class-dependent

I first ran this with `--spec-draft-p-min 0.60` and assumed the gate was the win. Then I measured it, which I should have done first. All three arms at 192K, q8_0, `--parallel 1` — only the spec flags vary:

| config | median | mean | code (py) | prose | acceptance |
|---|---|---|---|---|---|
| spec off | 69.3 | 69.3 | 69.3 | 69.2 | — |
| n-max 4, p-min 0.60 | 123.9 | 125.4 | 150.7 | 98.0 | 0.73 |
| **n-max 4, ungated** | **129.1** | 131.6 | 157.4 | 109.1 | 0.55 |

Ungated wins on every prompt: +4.2% overall median, +4.4% on code, +11.3% on prose. Smaller than @taco-devs' 26% loss in the 0.60–0.70 band (#12), but the same direction — and @jcr211's NVFP4 rig (#26) lands the same way, with gated n-max 4 (103.9) below ungated n-max 3 (108.7).

Three independent RTX 5090s, three different quants, all showing the gate costing throughput. The gate helps the bandwidth-starved cards it was discovered on; where verification is close to free it converts skipped drafts into plain decode rounds. Might be worth phrasing rule 2 as card-class-dependent rather than a default.

**Acceptance is a vanity metric on this class of card.** Gating moved it 0.55 → 0.73 while throughput went *down*. Tuning for acceptance picks the slower config.

## The `--parallel` trap, which nearly made me publish a wrong number twice

First I measured the baseline at `--parallel 2` and got 55.4 tok/s, making the MTP arm look like **+133%**. But `--parallel 1` is required by the draft-mtp path, so only the MTP arm was in a supported configuration. Re-running the baseline at `--parallel 1` gave **69.3** — `--parallel 2` alone costs ~20% of single-stream decode.

Then I nearly published the ungated number from a run at a different context and slot count than its baseline. Re-ran it under the baseline's own conditions for the table above.

Both are the same mistake, and the failure is asymmetric: a broken baseline flatters whatever you are trying to prove.

## Note on the 256K rows

Related to #14 — on the same card I could not run 256K, because this config carries an mmproj for vision. Text was fine (a 216,041-token prefill succeeded at 709 MiB free) but the vision encoder needs ~480 MiB **contiguous** at request time and OOMs, killing the server with `cudaMalloc failed` → `GGML_ASSERT`. Worth flagging for anyone matching a VRAM figure from a text-only row: loading is not proof.
