### PR TITLE
Add RTX 5090 power cap sweep (400-600W x n-max 0-6): MTP halves energy per token

### DIFF
--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -179,6 +179,72 @@ verify happens, never how well the draft guessed. This is rule 2 on a fresh
 axis: you can hand a rig a quarter of its speed back or take it away, and the
 acceptance number reports the same value throughout. Tune on tok/s.
 
+#### What a cap actually buys: energy per token
+
+Throughput is only half the question if you run this card for hours a day. The
+table below is the same n-max 4 data expressed as a trade, using **measured**
+draw rather than the cap setting, against the 600 W stock default:
+
+| Cap | Draw | tok/s | Power saved | Speed lost | J/token | kWh per 1M tok | Hours per 1M tok |
+|---|---|---|---|---|---|---|---|
+| 600 W | 602 W | 162.1 | — | — | 3.71 | 1.032 | 1.71 |
+| 550 W | 555 W | 158.8 | -7.8% | -2.0% | 3.50 | 0.971 | 1.75 |
+| 500 W | 511 W | 153.6 | -15.1% | -5.2% | 3.33 | 0.924 | 1.81 |
+| 450 W | 453 W | 142.7 | -24.8% | -12.0% | 3.17 | 0.882 | 1.95 |
+| 400 W | 411 W | 132.8 | **-31.7%** | -18.1% | **3.09** | **0.860** | 2.09 |
+
+At the 400 W floor you draw 31.7% less for 18.1% less speed: **every 1% of
+throughput surrendered buys about 1.75% of power.** Energy per token improves
+the whole way down and never turns around, so if you are optimising joules
+rather than latency, cap this card as low as it will go. That is worth
+contrasting with the RTX 3090 sweep in this file, which found efficiency peaking
+near 300 W of a 390 W default -- on Blackwell at 131K the curve has not turned
+by the time you reach the legal minimum. What you pay is wall clock: the same
+1M tokens occupies the card 1.71 h at 600 W and 2.09 h at 400 W.
+
+Spec-off the cap is close to free, because the baseline was never spending the
+watts in the first place:
+
+| Cap | Draw | tok/s | Power saved | Speed lost | J/token | kWh per 1M tok |
+|---|---|---|---|---|---|---|
+| 600 W | 537 W | 74.8 | — | — | 7.18 | 1.994 |
+| 550 W | 536 W | 74.8 | -0.2% | 0.0% | 7.17 | 1.990 |
+| 500 W | 509 W | 74.5 | -5.2% | -0.4% | 6.83 | 1.898 |
+| 450 W | 464 W | 73.5 | -13.6% | -1.7% | 6.31 | 1.754 |
+| 400 W | 407 W | 71.2 | -24.2% | -4.8% | 5.72 | 1.588 |
+
+Read the 550 W row: the cap comes down 50 W and nothing happens at all, because
+spec-off decode was already topping out at 537 W. Down at the floor it gives up
+24.2% of its draw for 4.8% of its speed -- a far better bargain than the spec
+arm gets, precisely because it had idle headroom to surrender.
+
+The larger result is the comparison between the arms rather than between the
+caps. **MTP roughly halves the energy cost of a token at every power setting:**
+
+| Cap | baseline J/token | n-max 4 J/token | Change |
+|---|---|---|---|
+| 400 W | 5.72 | 3.09 | **-45.9%** |
+| 450 W | 6.31 | 3.17 | -49.7% |
+| 500 W | 6.83 | 3.33 | -51.3% |
+| 550 W | 7.17 | 3.49 | -51.2% |
+| 600 W | 7.18 | 3.71 | **-48.3%** |
+
+So the flag is not only a throughput feature, it is a **~2x efficiency
+feature**: the same tokens for about half the electricity. The multi-GPU
+sweep's line that "the draft head is not buying speed with watts" holds here in
+a stronger form --
+it is buying speed *and* cutting watts per token, and that is true whether the
+card is capped or not.
+
+In money, at a placeholder 0.15 EUR/kWh, one million generated tokens costs
+about 0.30 EUR spec-off at stock power, 0.155 EUR at n-max 4, and 0.129 EUR at
+n-max 4 capped to 400 W. Substitute your own tariff; the ratios are what
+transfer. Two caveats worth stating plainly: these are **GPU draw only** -- no
+CPU, RAM, PSU conversion losses or cooling, so whole-system cost is higher and
+the percentage savings are smaller measured against that larger base -- and
+1 Hz sampling of `power.draw` is a decent estimate of energy, not a wall-meter
+reading.
+
 #### VRAM is linear in draft depth, and power-invariant
 
 Peak `memory.used`, identical in all 15 passes at every cap:

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -90,3 +90,151 @@ Config 2: Unsloth UD_Q4_K_XL, Context 262K, Q4_0 KV Cache, MMPROJ loaded, VRAM: 
 
 **n-max 4** is the sweet spot (Interestingly, with 131K it wasn't any different, but with 262K it was). 
 
+
+
+### RTX 5090 32GB: the power cap taxes the flag, not the baseline (400-600 W)
+*by [@cmoro-deusto](https://github.com/cmoro-deusto), PR #NN*
+
+Same machine and config as my row: ASUS TUF RTX 5090 32GB, unsloth UD-Q4_K_XL,
+131K context, q4_0 KV, `--parallel 1`, llama.cpp b10451 (`10bf611e5`), Arch
+Linux 7.1.8 / CUDA. The card's legal power range is 400-600 W and 600 W is the
+stock default, so this sweeps the entire range in 50 W steps.
+
+Every cell is **three complete passes** of baseline + n-max 1-6, 105 scenario
+runs in total, each pass a fresh `llama-server` per scenario. Throughput is the
+mean of all 27 runs per cell (3 passes x 3 prompts x 3 runs); power is p95 of
+1 Hz `nvidia-smi` sampling during each scenario, which is decode -- model load
+and warmup sit far below it. Method differs from stock `probe.py`: the harness
+orchestrates the server and reads `timings_per_token`, but sends the same three
+prompts, three runs each, 400 max tokens, thinking off, and leaves prompt
+caching at the server default.
+
+Reproducer and raw data, all in my fork:
+[`bench.py`](https://github.com/cmoro-deusto/qwen38-mtp/blob/bench/bench.py)
+(the per-scenario harness),
+[`sweep_power.sh`](https://github.com/cmoro-deusto/qwen38-mtp/blob/bench/sweep_power.sh)
+(drives it across caps and samples the GPU),
+[`summarize_power.py`](https://github.com/cmoro-deusto/qwen38-mtp/blob/bench/summarize_power.py),
+and the complete run behind every table below --- server logs, per-run probe
+detail, `results.json` and 1 Hz telemetry for all 105 scenario runs --- under
+[`sweep-data/rtx5090-power-cap-400-600w/`](https://github.com/cmoro-deusto/qwen38-mtp/tree/bench/sweep-data/rtx5090-power-cap-400-600w).
+
+#### Throughput, mean tok/s
+
+| Cap | baseline | n1 | n2 | n3 | n4 | n5 | n6 |
+|---|---|---|---|---|---|---|---|
+| 400 W | 71.2 | 108.4 | 129.3 | **133.8** | 132.8 | 127.5 | 123.3 |
+| 450 W | 73.5 | 113.2 | 136.0 | **144.2** | 142.7 | 138.8 | 134.0 |
+| 500 W | 74.5 | 114.9 | 139.8 | 152.9 | **153.6** | 148.8 | 142.7 |
+| 550 W | 74.8 | 115.8 | 145.0 | 154.8 | **158.8** | 155.2 | 151.0 |
+| 600 W | 74.8 | 115.7 | 144.4 | 156.0 | **162.1** | 159.7 | 153.2 |
+
+**Cutting power from 600 W to 400 W costs the baseline 4.8% and n4 18.1%.** The
+penalty grows monotonically with draft depth (loss relative to the 600 W figure):
+baseline -4.8%, n1 -6.3%, n2 -10.5%, n3 -14.2%, n4 -18.1%, n5 -20.2%, n6 -19.5%.
+So the flag's payoff is power-dependent in a way the baseline is not: MTP at n4
+is **+117%** over spec-off at 600 W but only **+87%** at 400 W. A third less
+power costs a quarter of the gain, and all of it comes out of the spec arm.
+
+#### Why: the baseline cannot spend the watts
+
+p95 draw during decode, median of the three passes:
+
+| Cap | baseline | n1 | n2 | n3 | n4 | n5 | n6 |
+|---|---|---|---|---|---|---|---|
+| 400 W | 407 | 408 | 407 | 412 | 411 | 409 | 408 |
+| 450 W | 464 | 457 | 459 | 454 | 453 | 456 | 457 |
+| 500 W | 509 | 509 | 508 | 509 | 511 | 503 | 510 |
+| 550 W | 536 | 546 | 557 | 554 | 555 | 560 | 560 |
+| 600 W | **537** | 554 | 602 | 603 | 602 | 601 | 601 |
+
+Spec-off decode saturates at **~537 W** and stays there whether the ceiling is
+550 or 600. It is bandwidth-bound: there is no more work to draw power for. n1
+reaches ~554 W; n2 and deeper peg the 600 W limit. Verifying a batch of drafted
+tokens is compute the baseline never performs, so raising the ceiling only helps
+the arm that has work to fill it -- and lowering the ceiling only takes from
+that arm. Below 500 W every arm is clamped equally and the flag is simply
+running at reduced clocks.
+
+Practical consequence: on this card the last 50 W of the stock budget (the
+550 -> 600 step) is worth nothing spec-off and ~2% at n4, while the first
+100 W off the top (600 -> 500) costs n4 5% and the baseline nothing.
+
+#### Acceptance does not move with power at all
+
+Aggregate acceptance from server timings, drafted vs accepted pooled per cell:
+
+| Cap | n1 | n2 | n3 | n4 | n5 | n6 |
+|---|---|---|---|---|---|---|
+| 400 W | 0.883 | 0.800 | 0.719 | 0.643 | 0.585 | 0.532 |
+| 450 W | 0.883 | 0.797 | 0.725 | 0.654 | 0.589 | 0.544 |
+| 500 W | 0.883 | 0.798 | 0.734 | 0.660 | 0.598 | 0.533 |
+| 550 W | 0.884 | 0.814 | 0.719 | 0.642 | 0.593 | 0.528 |
+| 600 W | 0.889 | 0.790 | 0.725 | 0.647 | 0.591 | 0.537 |
+
+Read the columns: they are flat to within a percentage point while throughput in
+the same cells swings up to 25%. Acceptance is a property of draft depth and the
+prompt, and nothing else here touches it -- the power cap changes how fast the
+verify happens, never how well the draft guessed. This is rule 2 on a fresh
+axis: you can hand a rig a quarter of its speed back or take it away, and the
+acceptance number reports the same value throughout. Tune on tok/s.
+
+#### VRAM is linear in draft depth, and power-invariant
+
+Peak `memory.used`, identical in all 15 passes at every cap:
+
+| Arm | MiB | vs baseline |
+|---|---|---|
+| baseline | 19,926 | — |
+| n1 | 21,068 | +1,142 |
+| n2 | 21,218 | +1,292 |
+| n3 | 21,368 | +1,442 |
+| n4 | 21,518 | +1,592 |
+| n5 | 21,666 | +1,740 |
+| n6 | 21,816 | +1,890 |
+
+Turning MTP on costs ~1.14 GB; each further unit of `--spec-draft-n-max` costs a
+flat **+150 MiB**. Budget accordingly on a card where the quant already fits
+tightly -- the depth you can afford is a straight-line calculation.
+
+#### Prose is what a power cap actually destroys
+
+Per-prompt medians of 9 runs, the two ends of the range:
+
+| Prompt | Cap | baseline | n1 | n2 | n3 | n4 | n5 | n6 |
+|---|---|---|---|---|---|---|---|---|
+| P1 code | 600 W | 74.6 | 121.6 | 163.9 | 185.4 | 203.9 | 203.0 | 204.0 |
+| P1 code | 400 W | 71.2 | 114.6 | 144.4 | 160.0 | 168.2 | 165.0 | 167.1 |
+| P2 prose | 600 W | 74.9 | 106.9 | 123.1 | 123.7 | 116.2 | 106.7 | 95.7 |
+| P2 prose | 400 W | 71.5 | 101.2 | 107.1 | 104.7 | 93.5 | 85.8 | **77.3** |
+| P3 bash | 600 W | 74.7 | 118.1 | 145.8 | 158.4 | 164.4 | 170.0 | 159.2 |
+| P3 bash | 400 W | 70.9 | 111.0 | 136.1 | 134.8 | 134.2 | 127.5 | 126.2 |
+
+At 400 W, n-max 6 on the prose prompt returns 77.3 against a 71.5 baseline --
+the flag has been reduced to noise. The same arm at 600 W returns 95.7. Deep
+drafts on low-acceptance content are exactly the combination a power cap
+punishes: you pay full verification cost for tokens that get thrown away, and
+capped clocks make each wasted verify more expensive. If you must cap this card
+and your traffic is prose-heavy, drop to n-max 2.
+
+#### On the optimum moving, and on noise
+
+The bolded optima above shift shallower as the cap tightens -- n4 at 500 W and
+up, n3 at 450 W and below. I would not lean hard on that: near the peak the arms
+sit within run-to-run scatter (stdev of the 9 runs per prompt is 2.5-9 tok/s for
+n4-n6, against 0.2-0.3 for the baseline). The **depth-dependent power
+sensitivity** is the durable finding; the shifting optimum is its mild
+consequence, and the honest version is that anything from n3 to n5 is defensible
+at 600 W while n2-n3 is the safer pick at 400 W.
+
+One measurement note worth passing on. `probe.py`'s OVERALL median is the median
+of nine runs across three very different prompts, and on this rig it lands
+inside the bash cluster every single time -- the pooled median column and the
+P3 row of this sweep are identical to the decimal. The mean of the nine, or the
+per-prompt medians, are what actually move when something changes. This is the
+same trap the RTX 3090 sweep flags from the other direction.
+
+Baseline stability is worth recording too: spec-off ran 71.2/73.5/74.5/74.8/74.8
+across the five caps with a stdev of 0.2-0.3 tok/s within each cell. When the
+baseline is that flat, a paired delta is trustworthy; when it is not, suspect
+the host before the flag (rule 7).

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -93,7 +93,7 @@ Config 2: Unsloth UD_Q4_K_XL, Context 262K, Q4_0 KV Cache, MMPROJ loaded, VRAM: 
 
 
 ### RTX 5090 32GB: the power cap taxes the flag, not the baseline (400-600 W)
-*by [@cmoro-deusto](https://github.com/cmoro-deusto), PR #NN*
+*by [@cmoro-deusto](https://github.com/cmoro-deusto), PR #47*
 
 Same machine and config as my row: ASUS TUF RTX 5090 32GB, unsloth UD-Q4_K_XL,
 131K context, q4_0 KV, `--parallel 1`, llama.cpp b10451 (`10bf611e5`), Arch

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -245,6 +245,13 @@ the percentage savings are smaller measured against that larger base -- and
 1 Hz sampling of `power.draw` is a decent estimate of energy, not a wall-meter
 reading.
 
+If the cost angle is what brought you here, I took these figures further in a
+separate write-up: [Local AI vs Cloud AI: A Cost
+Analysis](https://github.com/cmoro-deusto/qwen38-mtp/blob/bench/LocalAI_vs_CloudAI_Costs_Analysis.md)
+puts the running cost of this card against per-token API pricing for eight
+hosted models, and against where Qwen3.8-27B actually lands on the Artificial
+Analysis Agentic Index.
+
 #### VRAM is linear in draft depth, and power-invariant
 
 Peak `memory.used`, identical in all 15 passes at every cap:


### PR DESCRIPTION
A sweep of the GPU power cap against draft depth on one ASUS TUF RTX 5090
32GB. Adds one section to sweeps/rtx-5090.md; no table row, no changes to
anyone else's content.

Five caps (400/450/500/550/600 W, the card's full legal range in 50 W
steps) x three complete passes x baseline + n-max 1-6 = 105 scenario runs,
each a fresh llama-server. Same config as my table row in #43:
unsloth UD-Q4_K_XL, 131K context, q4_0 KV, --parallel 1, llama.cpp b10451.

What it found:

- The cap taxes the flag, not the baseline. 600 W -> 400 W costs spec-off
  4.8% and n4 18.1%, and the penalty grows monotonically with draft depth.
  MTP at n4 is +117% over baseline at 600 W but only +87% at 400 W.
- Why: spec-off decode saturates at ~537 W and never reaches a 550 or
  600 W ceiling -- it is bandwidth-bound with no work to spend watts on.
  n2 and deeper peg 600 W. Verification is the compute the baseline
  never performs.
- Energy per token, which is the practical question if the card runs for
  hours a day: at the 400 W floor it draws 31.7% less for 18.1% less
  speed, so every 1% of throughput surrendered buys ~1.75% of power.
  Efficiency improves monotonically all the way to the legal minimum --
  no sweet spot in the middle, unlike the 3090 sweep in the same file.
  And MTP itself roughly halves joules per token against spec-off at
  every cap (-46% to -51%), so the flag is a ~2x efficiency feature and
  not only a throughput one.
- Acceptance is completely power-invariant: flat to a percentage point
  across the whole range while throughput in the same cells swings 25%.
  Rule 2 on a fresh axis.
- VRAM is linear in draft depth: +1142 MiB to enable MTP, then a flat
  +150 MiB per unit of --spec-draft-n-max, identical in all 15 passes.
- At 400 W, n-max 6 on the prose prompt returns 77.3 against a 71.5
  baseline -- the flag reduced to noise.

Caveats stated in the section: the method is my own harness rather than
stock probe.py (same prompts, runs, token count and thinking-off, but it
orchestrates the server and reads timings_per_token), and the apparent
shift in the n-max optimum sits within run-to-run scatter, so the section
says so rather than claiming a new sweet spot.

Scripts and the complete raw run (server logs, per-run probe detail,
results.json, 1 Hz GPU telemetry for all 105 runs) are linked from the
section and live in my fork. Energy figures are GPU draw only (no CPU,
PSU losses or cooling) and come from the same 1 Hz sampling, stated as
such in the section.
