### PR TITLE
Add RTX 5090 + 3080 entry to performance table

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 4090 24GB (Purusha, LoRA merge) | 47.0 | 83.4 | 2 | — | [@snakeyjay63-png](https://github.com/snakeyjay63-png) |
 | Tesla V100 32GB (Volta) | 33.3 | 48.0 | 2 | 0.75 | [@cameron](https://github.com/cameron) |
 | RTX 5060 Ti 16GB (Q4-XYZ-v2, 32K) | 26.3 | 59.5 | 4 | 0.34-0.69 | [@jaisusx](https://github.com/jaisusx) |
+| RTX 5090 + RTX3080 (Q8_0, 131K, `-ts 26,6`) | 38.1 | 86.8 | 3 | 74.7 | [@lasq88](https://github.com/lasq88) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | Tesla V100 32GB (Volta) | 33.3 | 48.0 | 2 | 0.75 | [@cameron](https://github.com/cameron) |
 | RTX 5060 Ti 16GB (Q4-XYZ-v2, 32K) | 26.3 | 59.5 | 4 | 0.34-0.69 | [@jaisusx](https://github.com/jaisusx) |
 | RTX 5090 + RTX3080 (Q8_0, 131K, `-ts 26,6`) | 38.1 | 86.8 | 3 | 74.7 | [@lasq88](https://github.com/lasq88) |
+| Single RTX 5090 (Q4_K_M, 262K)| 75.4 | 153.8 | 4 | 86.5 | [@lasq88](https://github.com/lasq88) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.


### PR DESCRIPTION
RTX5090 + RTX3080 total 42GB VRAM. Layer split  -ts 26,6 managed to fit Q8_0 quant with 131K context and cache quant q4_0. Slightly slower than Q4_K_M only on 5090 but hopefully better quality.