### PR TITLE
RTX 5090: add Qwen3.8-27B Dynamic 3.0 MTP benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Ran the A/B on your card? Open a PR and add a row.
 | RTX 5090 32GB (UD-Q4_K_XL **Dynamic 3.0**, 192K) | 74.7 | 160.8 | 4 | 0.86-0.93 | [@paulomcg](https://github.com/paulomcg) |
 | RTX 5080 16GB | 53.4 | 101.3 | 2 | 0.53-0.95 | [@ChumBoxBaron](https://github.com/ChumBoxBaron) |
 | RTX 4060 Ti 16GB (Q4-XYZ-v2, 32K) | 17.6 | 40.0 | 3 | 0.41-0.94 | [@CeIest2](https://github.com/CeIest2) |
+| RTX 5090 32GB (UD-Q4_K_XL Dynamic 3.0, 131K, b10680) | 71.9 | 170.3 | 7 | 0.19-0.85 (0.48 aggregate) | [@hagope](https://github.com/hagope) |
 
 \* A6000 row: unsloth Q8_K_XL, 256K context, q8_0 KV cache — 40.0 GB VRAM baseline, 41.4 GB with spec (rows above: Q4_K_M, 131K, q4_0 KV).
 \* RX 7900 XTX row: unsloth Q4_K_M, 131K context, q4_0 KV cache — 18.9 GB VRAM baseline, 19.7 GB with spec.
@@ -187,6 +188,8 @@ Ran the A/B on your card? Open a PR and add a row.
 \* RTX 5080 16GB: unsloth Qwen3.8-27B Q3_K_M, ctx 65536, KV q4_0+q4_0, llama.cpp b10488, Windows 11 Pro / CUDA 13.3, VRAM 48 MiB idle → 14,445 MiB baseline / 15,359 MiB MTP, probe.py unchanged @master (both arms), `--parallel 1`, flash-attn on, thinking off.
 
 \* RTX 4060 Ti 16GB row: quimmedes/Qwen3.8-27B-XYZ Q4-XYZ-v2 (15,064,569,440 B, sha256 ab58f29fa81dd604… — same file as the 5060 Ti row above, making the two a controlled cross-card pair: 288 vs 448 GB/s), 32K context, q4_0 KV cache (both K and V), llama.cpp master `9a286ac` (2026-08-21) built from source with CUDA 12.8 (`-DCMAKE_CUDA_ARCHITECTURES=89`), Ubuntu 24.04 / CUDA, driver 580.173.02, desktop nearly idle during bench (~280 MiB GPU footprint). Method: unchanged `probe.py` at `c7bc415`, three runs x three prompts, thinking off, `--parallel 1` both arms. VRAM 14,778 MiB baseline / 15,830 MiB at n-max 3. Full n-max sweep (2/3/4 + p-min 0.70) and a Q4-XYZ v1-vs-v2 study in [sweeps/rtx-4060-ti.md](sweeps/rtx-4060-ti.md): depth pays to n-max 3 (+11% over n2), n-max 4 OOMs at load (same 130 MiB shortfall as the 5060 Ti's n-max 6, also with `-b 512 -ub 512`), p-min 0.70 gating is a wash at the ceiling (−0.5%, acceptance 0.72-0.98), and the quant version alone moves the depth optimum by a full step on identical silicon and build.
+
+\* RTX 5090 b10680 row: unsloth UD-Q4_K_XL Dynamic 3.0 (`Qwen3.8-27B-UD-Q4_K_XL.gguf`, 17,559,178,144 B, sha256 `3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e`), 131K context, q4_0 K/V cache, full GPU offload, flash attention, and `--parallel 1` on both arms. llama.cpp CUDA build 10680 (`d7bd3bfca`, image digest `sha256:952424b09abc…90c7`), Ubuntu 24.04.4 / kernel 6.8.0-138, NVIDIA driver 595.84, RTX 5090 at a 575 W limit. Loaded VRAM was 19,496 MiB baseline / 21,594 MiB at n-max 7. Method: unchanged `probe.py` at `668cb10f`, three complete passes per arm, each pass three runs x three prompts, thinking off; the row is the median of the three pass medians. Baseline passes: 71.9/71.8/71.9; n-max 7 passes: 170.3/158.4/180.3 (**+136.9%**, 2.37x). Only the MTP arm added `--spec-type draft-mtp --spec-draft-n-max 7`. Acceptance excludes warmups: 5,899/12,386 aggregate (0.476), per-request 0.19-0.85; code 0.769, prose 0.230, bash 0.479. Full depth sweep in [sweeps/rtx-5090.md](sweeps/rtx-5090.md): n-max 6 and 7 are tied within 0.5%, and n-max 8 turns down.
 
 ### Deep dives
 

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -379,3 +379,40 @@ prompt* ([140.2, 71.6, 117.0] on one arm). Rule 7 in the README is about a
 desktop compositor, but the same trap catches a headless box with a live
 inference workload on it. I now gate every arm on 60 seconds of sustained sub-15%
 utilization with zero busy slots before the server starts.
+
+
+### RTX 5090 32GB: Flash-Next UD-Q2_K_XL has no inline MTP head
+*by [@hagope](https://github.com/hagope)*
+
+I tested whether the same flag works with Unsloth's much larger
+`Qwen3.8-Flash-Next-GGUF` release. It does not for this quant: llama.cpp loads
+the baseline normally, but adding `--spec-type draft-mtp
+--spec-draft-n-max 2` aborts startup with `context type MTP requested but model
+doesn't contain MTP layers`. This is a compatibility result, not a main-table
+row; there is no valid MTP arm to pair with the baseline.
+
+Baseline throughput from unchanged `probe.py` at `668cb10f`, three complete
+passes (each pass is three prompts x three runs, thinking off):
+
+| pass | Overall median | P1 code (Python) | P2 prose (mmap) | P3 code (bash) |
+|---|---|---|---|---|
+| 1 | 21.1 | 21.1 | 21.5 | 21.1 |
+| 2 | 21.8 | 22.1 | 22.2 | 21.1 |
+| 3 | 22.3 | 22.7 | 22.5 | 22.0 |
+| **median** | **21.8** | **22.1** | **22.2** | **21.1** |
+
+Exact config: `unsloth/Qwen3.8-Flash-Next-GGUF` UD-Q2_K_XL snapshot
+`c8b5954a88c2775c546b92593eda40ea041d3176` (model metadata reports
+176,943,899,520 parameters and 78,858,104,320 bytes), 131,072 context, q8_0 K/V
+cache, `--parallel 1`, all layers requested on GPU with `--n-cpu-moe 28`,
+`--tensor-read-lazy auto`, batch/ubatch 4096/2048, flash attention, and 12 CPU
+threads. Baseline loaded VRAM was 28,364 MiB. The host is Ubuntu 24.04.4, kernel
+6.8.0-138, NVIDIA driver 595.84, Core Ultra 9 285K, and RTX 5090 at its stock
+575 W limit. llama.cpp is CUDA build 10680, commit `d7bd3bfca`.
+
+The failed arm used the same image, model, context, cache, offload, and serving
+arguments; only the two MTP options above were added. The rejection occurs
+after target-model load while llama.cpp creates the draft context, before the
+HTTP server starts. The narrow conclusion is that this UD-Q2_K_XL snapshot
+does not carry the inline MTP tensors; it says nothing about other Flash-Next
+quants or a future re-upload.

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -381,38 +381,43 @@ inference workload on it. I now gate every arm on 60 seconds of sustained sub-15
 utilization with zero busy slots before the server starts.
 
 
-### RTX 5090 32GB: Flash-Next UD-Q2_K_XL has no inline MTP head
+### RTX 5090 32GB: current llama.cpp pushes Dynamic 3.0 to n-max 6-7
 *by [@hagope](https://github.com/hagope), PR #68*
 
-I tested whether the same flag works with Unsloth's much larger
-`Qwen3.8-Flash-Next-GGUF` release. It does not for this quant: llama.cpp loads
-the baseline normally, but adding `--spec-type draft-mtp
---spec-draft-n-max 2` aborts startup with `context type MTP requested but model
-doesn't contain MTP layers`. This is a compatibility result, not a main-table
-row; there is no valid MTP arm to pair with the baseline.
+This pairs Unsloth's UD-Q4_K_XL Dynamic 3.0 at 131K with llama.cpp b10680,
+keeping the model, context, q4_0 K/V cache, full GPU offload, flash attention,
+and `--parallel 1` fixed. The baseline and final n-max 6/7 cells are medians of
+three complete `probe.py` passes; the other depths are one pass each (three
+runs per prompt), all thinking off:
 
-Baseline throughput from unchanged `probe.py` at `668cb10f`, three complete
-passes (each pass is three prompts x three runs, thinking off):
+| n-max | Overall | P1 code (Python) | P2 prose (mmap) | P3 code (bash) | Complete passes |
+|---|---|---|---|---|---|
+| off | 71.9 | 71.9 | 72.2 | 71.8 | 3 |
+| 2 | 117.2 | 130.1 | 99.5 | 117.2 | 1 |
+| 3 | 125.5 | 150.3 | 89.1 | 125.5 | 1 |
+| 4 | 127.4 | 145.8 | 85.0 | 127.4 | 1 |
+| 5 | 166.5 | 222.5 | 100.0 | 166.5 | 1 |
+| 6 | 169.4 | 226.3 | 102.8 | 169.4 | 3 |
+| **7** | **170.3** | **235.2** | **99.1** | **170.3** | **3** |
+| 8 | 151.6 | 234.9 | 92.9 | 151.6 | 1 |
 
-| pass | Overall median | P1 code (Python) | P2 prose (mmap) | P3 code (bash) |
-|---|---|---|---|---|
-| 1 | 21.1 | 21.1 | 21.5 | 21.1 |
-| 2 | 21.8 | 22.1 | 22.2 | 21.1 |
-| 3 | 22.3 | 22.7 | 22.5 | 22.0 |
-| **median** | **21.8** | **22.1** | **22.2** | **21.1** |
+The durable result is the n-max 6-7 plateau, not the 0.5% ordering inside it:
+both are a 2.36-2.37x gain over spec-off, and n-max 8 has clearly turned down.
+The n-max 7 row uses complete-pass medians 170.3/158.4/180.3 against the
+baseline's 71.9/71.8/71.9. Its median per-prompt split is 235.2 code, 99.1
+prose, and 170.3 bash; the corresponding median of the three pass means is
+169.5 tok/s.
 
-Exact config: `unsloth/Qwen3.8-Flash-Next-GGUF` UD-Q2_K_XL snapshot
-`c8b5954a88c2775c546b92593eda40ea041d3176` (model metadata reports
-176,943,899,520 parameters and 78,858,104,320 bytes), 131,072 context, q8_0 K/V
-cache, `--parallel 1`, all layers requested on GPU with `--n-cpu-moe 28`,
-`--tensor-read-lazy auto`, batch/ubatch 4096/2048, flash attention, and 12 CPU
-threads. Baseline loaded VRAM was 28,364 MiB. The host is Ubuntu 24.04.4, kernel
-6.8.0-138, NVIDIA driver 595.84, Core Ultra 9 285K, and RTX 5090 at its stock
-575 W limit. llama.cpp is CUDA build 10680, commit `d7bd3bfca`.
+Acceptance explains the workload split. Across the 27 scored n-max 7 requests
+(warmups excluded), code accepted 2,574/3,346 drafts (0.769), prose only
+934/4,053 (0.230), and bash 2,391/4,987 (0.479). Overall acceptance is
+5,899/12,386 (0.476), range 0.19-0.85. Deep drafting pays despite the low
+aggregate because verification is cheap on this card; optimizing for a higher
+acceptance number would choose the slower arm.
 
-The failed arm used the same image, model, context, cache, offload, and serving
-arguments; only the two MTP options above were added. The rejection occurs
-after target-model load while llama.cpp creates the draft context, before the
-HTTP server starts. The narrow conclusion is that this UD-Q2_K_XL snapshot
-does not carry the inline MTP tensors; it says nothing about other Flash-Next
-quants or a future re-upload.
+Exact artifact and host: 17,559,178,144-byte GGUF, sha256
+`3f227079003add2511437e5b1e94812e363385225bf6a9b47b0054a72bc8b01e`,
+llama.cpp CUDA build 10680 (`d7bd3bfca`, container digest
+`sha256:952424b09abc…90c7`), Ubuntu 24.04.4 / kernel 6.8.0-138, NVIDIA driver
+595.84, and a 575 W power limit. Loaded VRAM was 19,496 MiB spec-off and 21,594
+MiB at n-max 7. The 131,072-token slot was confirmed in both arms.

--- a/sweeps/rtx-5090.md
+++ b/sweeps/rtx-5090.md
@@ -382,7 +382,7 @@ utilization with zero busy slots before the server starts.
 
 
 ### RTX 5090 32GB: Flash-Next UD-Q2_K_XL has no inline MTP head
-*by [@hagope](https://github.com/hagope)*
+*by [@hagope](https://github.com/hagope), PR #68*
 
 I tested whether the same flag works with Unsloth's much larger
 `Qwen3.8-Flash-Next-GGUF` release. It does not for this quant: llama.cpp loads


### PR DESCRIPTION
## Summary

- adds a paired Qwen3.8-27B UD-Q4_K_XL Dynamic 3.0 result for the RTX 5090
- records 71.9 tok/s baseline and 170.3 tok/s at n-max 7 (+136.9%, 2.37x)
- includes the n-max 2-8 sweep, three-complete-pass validation for baseline and n-max 6/7, acceptance, VRAM, artifact hash, and full host/build metadata

## Method

- unchanged `probe.py` at `668cb10f`
- both arms use the same 131K context, q4_0 K/V cache, full GPU offload, flash attention, and `--parallel 1`
- three complete passes per final arm, each with three prompts x three runs, thinking off
- only the MTP arm adds `--spec-type draft-mtp --spec-draft-n-max 7`

## Validation

- GGUF SHA-256 verified against the Dynamic 3.0 artifact
- 131,072-token slot confirmed in both arms
- `git diff --check`

This replaces the initial Flash-Next compatibility result, which benchmarked the wrong model.